### PR TITLE
feat: first step for implementing meta-cli

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	"github.com/urfave/cli"
+)
+
+// VERSION gets set by the build script via the LDFLAGS
+var VERSION string
+
+func getMeta(key string, metaSpace string) {
+}
+
+func setMeta(key string, value string, metaSpace string) {
+}
+
+var cleanExit = func() {
+	os.Exit(0)
+}
+
+// finalRecover makes one last attempt to recover from a panic.
+// This should only happen if the previous recovery caused a panic.
+func finalRecover() {
+	if p := recover(); p != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+	}
+	cleanExit()
+}
+
+func main() {
+	defer finalRecover()
+
+	app := cli.NewApp()
+	app.Name = "meta-cli"
+	app.Usage = "get or set metadata for Screwdriver build"
+	app.UsageText = "meta command arguments [options]"
+	app.Copyright = "(c) 2017 Yahoo Inc."
+
+	if VERSION == "" {
+		VERSION = "0.0.0"
+	}
+	app.Version = VERSION
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "meta-space",
+			Usage: "Location for saving meta temporarily",
+			Value: "/sd/meta",
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:  "get",
+			Usage: "Get a metadata with key",
+			Action: func(c *cli.Context) error {
+				if len(c.Args()) == 0 {
+					return cli.ShowAppHelp(c)
+				}
+				metaSpace := c.String("meta-space")
+				getMeta(c.Args().First(), metaSpace)
+				return nil
+			},
+		},
+		{
+			Name:  "set",
+			Usage: "Set a metadata with key and value",
+			Action: func(c *cli.Context) error {
+				if len(c.Args()) <= 1 {
+					return cli.ShowAppHelp(c)
+				}
+				metaSpace := c.String("meta-space")
+				setMeta(c.Args().Get(0), c.Args().Get(1), metaSpace)
+				return nil
+			},
+		},
+	}
+
+	app.Run(os.Args)
+}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,3 @@
+package main
+
+import ()

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,33 @@
+workflow:
+    - deploy
+
+shared:
+    image: golang
+    environment:
+        GOPATH: /sd/workspace
+
+jobs:
+    main:
+        steps:
+            - get: go get -t ./...
+            - vet: go vet ./...
+            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - test: go test ./...
+            - build: go build -a -o meta
+
+    deploy:
+        steps:
+            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - get: go get -t ./...
+            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - build: go build -a -o meta
+            - get-bzip2: apt-get update && apt-get install -y --no-install-recommends bzip2
+            - tag: ./ci/git-tag.sh
+            - release: ./ci/git-release.sh
+        secrets:
+            # Pushing tags to Git
+            - GIT_KEY
+            # Pushing releases to GitHub
+            - GITHUB_TOKEN
+        environment:
+            RELEASE_FILE: meta


### PR DESCRIPTION
This PR provides interface of the meta-cli.
I wrote `screwdriver.yaml` and `meta.go` based on [launcher](https://github.com/screwdriver-cd/launcher).

The help message of meta-cli is following:
```
% go build -o meta                                                                                                                 
% ./meta                                                                                                                           
NAME:
   meta-cli - get or set metadata for Screwdriver build

USAGE:
   meta command arguments [options]

VERSION:
   0.0.0

COMMANDS:
     get      Get a metadata with key
     set      Set a metadata with key and value
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --meta-space value  Location for saving meta temporarily (default: "/tmp/meta")
   --help, -h          show help
   --version, -v       print the version

COPYRIGHT:
   (c) 2017 Yahoo Inc.
```

Related: https://github.com/screwdriver-cd/screwdriver/issues/293