### PR TITLE
feat: implement meta-cli and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+meta-cli
 
 # Folders
 _obj

--- a/meta.go
+++ b/meta.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
+	"reflect"
 	"runtime/debug"
+	"strconv"
 
 	"github.com/urfave/cli"
 )
@@ -11,10 +16,177 @@ import (
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
 
-func getMeta(key string, metaSpace string) {
+var mkdirAll = os.MkdirAll
+var stat = os.Stat
+var writeFile = ioutil.WriteFile
+var readFile = ioutil.ReadFile
+var fprintf = fmt.Fprintf
+
+const metaFile = "meta.json"
+
+// Get meta from file based on key
+func getMeta(key string, metaSpace string, output io.Writer) {
+	metaFilePath := metaSpace + "/" + metaFile
+	metaJson, err := readFile(metaFilePath)
+	if err != nil {
+		panic(err)
+	}
+	var metaInterface map[string]interface{}
+	err = json.Unmarshal(metaJson, &metaInterface)
+	if err != nil {
+		panic(err)
+	}
+
+	result := metaInterface[key]
+	switch result.(type) {
+	case map[string]interface{}, []interface{}:
+		resultJson, _ := json.Marshal(result)
+		fprintf(output, "%v", string(resultJson))
+	case nil:
+		fprintf(output, "null")
+	default:
+		fprintf(output, "%v", result)
+	}
 }
 
+// Store meta to file with key and value
 func setMeta(key string, value string, metaSpace string) {
+	metaFilePath := metaSpace + "/" + metaFile
+	var previousMeta map[string]interface{}
+
+	_, err := stat(metaFilePath)
+	// Not exist directory
+	if err != nil {
+		setupDir(metaSpace)
+		// Initialize interface if first setting meta
+		previousMeta = make(map[string]interface{})
+	} else {
+		metaJson, _ := readFile(metaFilePath)
+		// Exist meta.json
+		if len(metaJson) != 0 {
+			err = json.Unmarshal(metaJson, &previousMeta)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			// Exist meta.json but it is empty
+			previousMeta = make(map[string]interface{})
+		}
+	}
+
+	key, parsedValue := parseMetaValue(key, value, previousMeta)
+	previousMeta[key] = parsedValue
+
+	resultJson, err := json.Marshal(previousMeta)
+
+	err = writeFile(metaFilePath, resultJson, 0666)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Parse arguments of meta-cli to JSON
+func parseMetaValue(key string, value string, previousMeta interface{}) (string, interface{}) {
+	for position, char := range key {
+		if string([]rune{char}) == "[" {
+			nextChar := key[position+1]
+			if nextChar == []byte("]")[0] {
+				// Value is array
+				var metaValue [1]interface{}
+				key = key[0:position] + key[position+2:] // Remove bracket[] from key
+				key, metaValue[0] = parseMetaValue(key, value, previousMeta)
+				return key, metaValue
+			} else {
+				// Value is array with index
+				var i int
+				for i = position + 1; ; i++ {
+					_, err := strconv.Atoi(string(key[i])) // Check the next char is integer
+					if err != nil {
+						break
+					}
+				}
+				metaIndex, _ := strconv.Atoi(key[position+1 : i]) // e.g. if array[10], get "10"
+				key = key[0:position] + key[i+1:]                 // Remove bracket[num] from key
+
+				// Convert previousMeta Interface to Map
+				previousMetaValue := reflect.ValueOf(previousMeta)
+				var previousMetaMap map[string]interface{}
+				previousMetaMap = make(map[string]interface{})
+				var previousKey string
+				if previousMetaValue.Kind() == reflect.Map {
+					for _, k := range previousMetaValue.MapKeys() {
+						previousKey, _ = k.Interface().(string)
+						previousMetaMap[previousKey] = previousMetaValue.MapIndex(k).Interface()
+					}
+				}
+
+				var metaValue []interface{}
+				// previousMetaMap[previousKey] is empty or string, create array with null except "value"
+				if previousMetaMap[previousKey] == nil || reflect.ValueOf(previousMetaMap[previousKey]).Kind() == reflect.String {
+					metaValue = make([]interface{}, metaIndex+1)
+					key, metaValue[metaIndex] = parseMetaValue(key, value, previousMetaMap[previousKey])
+					return key, metaValue
+				} else {
+					metaValue = make([]interface{}, metaIndex+1)
+					previousObject := reflect.ValueOf(previousMetaMap[previousKey])
+					if metaIndex+1 > previousObject.Len() {
+						metaValue = make([]interface{}, metaIndex+1)
+						key, metaValue[metaIndex] = parseMetaValue(key, value, nil)
+					} else {
+						metaValue = make([]interface{}, previousObject.Len())
+						key, metaValue[metaIndex] = parseMetaValue(key, value, previousObject.Index(metaIndex).Interface())
+					}
+					// Insert previousValues to a[] when previousObject is Array
+					if previousObject.Kind() == reflect.Slice {
+						for i := 0; i < previousObject.Len(); i++ {
+							if i != metaIndex {
+								metaValue[i] = previousObject.Index(i).Interface()
+							}
+						}
+					}
+					return key, metaValue
+				}
+			}
+		} else if string([]rune{char}) == "." {
+			// Value is object
+			childKey := key[position+1:]
+			key = key[0:position]
+			var obj map[string]interface{}
+			obj = make(map[string]interface{})
+			childKey, tmpValue := parseMetaValue(childKey, value, previousMeta)
+			obj[childKey] = tmpValue
+			return key, obj
+		}
+	}
+	// Value is int
+	i, err := strconv.Atoi(value)
+	if err == nil {
+		return key, i
+	}
+	// Value is float
+	f, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		return key, f
+	}
+	// Value is bool
+	b, err := strconv.ParseBool(value)
+	if err == nil {
+		return key, b
+	}
+	// Value is string
+	return key, value
+}
+
+// setupDir makes directory and json file for meta
+func setupDir(metaSpace string) {
+	err := mkdirAll(metaSpace, 0777)
+	if err != nil {
+		panic(err)
+	}
+	err = writeFile(metaSpace+"/"+metaFile, []byte(""), 0666)
+	if err != nil {
+		panic(err)
+	}
 }
 
 var cleanExit = func() {
@@ -26,13 +198,15 @@ var cleanExit = func() {
 func finalRecover() {
 	if p := recover(); p != nil {
 		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, string(debug.Stack()))
 	}
 	cleanExit()
 }
 
 func main() {
 	defer finalRecover()
+
+	var metaSpace string
 
 	app := cli.NewApp()
 	app.Name = "meta-cli"
@@ -47,9 +221,10 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "meta-space",
-			Usage: "Location for saving meta temporarily",
-			Value: "/sd/meta",
+			Name:        "meta-space",
+			Usage:       "Location of meta temporarily",
+			Value:       "/sd/meta",
+			Destination: &metaSpace,
 		},
 	}
 
@@ -61,10 +236,10 @@ func main() {
 				if len(c.Args()) == 0 {
 					return cli.ShowAppHelp(c)
 				}
-				metaSpace := c.String("meta-space")
-				getMeta(c.Args().First(), metaSpace)
+				getMeta(c.Args().First(), metaSpace, os.Stdout)
 				return nil
 			},
+			Flags: app.Flags,
 		},
 		{
 			Name:  "set",
@@ -73,10 +248,10 @@ func main() {
 				if len(c.Args()) <= 1 {
 					return cli.ShowAppHelp(c)
 				}
-				metaSpace := c.String("meta-space")
 				setMeta(c.Args().Get(0), c.Args().Get(1), metaSpace)
 				return nil
 			},
+			Flags: app.Flags,
 		},
 	}
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -40,49 +40,49 @@ func TestGetMeta(t *testing.T) {
 	getMeta("str", mockDir, stdout)
 	expected := []byte("fuga")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("bool", mockDir, stdout)
 	expected = []byte("true")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("int", mockDir, stdout)
 	expected = []byte("1")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("float", mockDir, stdout)
 	expected = []byte("1.5")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("obj", mockDir, stdout)
 	expected = []byte("{\"ccc\":\"ddd\",\"momo\":{\"toke\":\"toke\"}}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("ary", mockDir, stdout)
 	expected = []byte("[\"aaa\",\"bbb\"]")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("nu", mockDir, stdout)
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 }
 
@@ -106,7 +106,7 @@ func TestSetMeta_bool(t *testing.T) {
 	}
 	expected := []byte("{\"bool\":true}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 func TestSetMeta_number(t *testing.T) {
@@ -121,7 +121,7 @@ func TestSetMeta_number(t *testing.T) {
 	}
 	expected := []byte("{\"float\":15.5,\"int\":10}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -136,7 +136,7 @@ func TestSetMeta_string(t *testing.T) {
 	}
 	expected := []byte("{\"str\":\"val\"}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -151,7 +151,7 @@ func TestSetMeta_array(t *testing.T) {
 	}
 	expected := []byte("{\"array\":[\"arg\"]}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -166,7 +166,7 @@ func TestSetMeta_array_with_index(t *testing.T) {
 	}
 	expected := []byte("{\"array\":[null,\"arg\"]}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
 	setMeta("array[2]", "argarg", testDir)
@@ -176,7 +176,7 @@ func TestSetMeta_array_with_index(t *testing.T) {
 	}
 	expected = []byte("{\"array\":[null,\"arg\",\"argarg\"]}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -192,7 +192,7 @@ func TestSetMeta_array_with_index_to_string(t *testing.T) {
 	}
 	expected := []byte("{\"array\":\"str\"}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -207,7 +207,7 @@ func TestSetMeta_object(t *testing.T) {
 	}
 	expected := []byte("{\"foo\":{\"bar\":\"baz\"}}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
 	setMeta("foo.bar.baz", "piyo", testDir)
@@ -217,7 +217,7 @@ func TestSetMeta_object(t *testing.T) {
 	}
 	expected = []byte("{\"foo\":{\"bar\":{\"baz\":\"piyo\"}}}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -233,7 +233,7 @@ func TestSetMeta_object_to_string(t *testing.T) {
 	}
 	expected := []byte("{\"foo\":\"baz\"}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 }
 
@@ -248,7 +248,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 	}
 	expected := []byte("{\"foo\":[null,{\"bar\":\"baz\"}]}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
 	setMeta("foo.bar[1]", "baz", testDir)
@@ -258,7 +258,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 	}
 	expected = []byte("{\"foo\":{\"bar\":[null,\"baz\"]}}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
 	setMeta("foo[1].bar[1]", "baz", testDir)
@@ -268,7 +268,132 @@ func TestSetMeta_array_with_object(t *testing.T) {
 	}
 	expected = []byte("{\"foo\":[null,{\"bar\":[null,\"baz\"]}]}")
 	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+}
+
+func TestMetaSetValidatorWithAccept(t *testing.T) {
+	testKey := "foo"
+	r := validateMetaKey(testKey)
+	if r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
 	}
 
+	testKey = "foo[]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[0]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[1]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[10]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "a[10][20]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo.bar"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[].bar"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[1].bar"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo.bar[]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo.bar[1]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[].bar[]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[1].bar[1]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo.bar.baz"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "foo[1].bar[2].baz[3]"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+
+	testKey = "1.2.3"
+	if r = validateMetaKey(testKey); r == false {
+		t.Fatalf("'%v' is should be accepted", testKey)
+	}
+}
+
+func TestMetaSetValidatorWithReject(t *testing.T) {
+	testKey := "foo[["
+	r := validateMetaKey(testKey)
+	if r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo[]]"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo[[]]"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo[1e]"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo[01]"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo."
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "foo.[]"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
+
+	testKey = "a-b"
+	if r = validateMetaKey(testKey); r == true {
+		t.Fatalf("'%v' is should be rejected", testKey)
+	}
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,3 +1,275 @@
 package main
 
-import ()
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+const testDir = "./_test"
+const testFilePath = testDir + "/" + metaFile
+const mockDir = "./mock"
+
+func TestMain(m *testing.M) {
+	// setup functions
+	setupDir(testDir)
+	//readFile = func(filename string) ([]byte, error) { return ioutil.ReadFile("./test/test.json") }
+	writeFile = func(filename string, data []byte, perm os.FileMode) error {
+		return ioutil.WriteFile(testFilePath, data, 0666)
+	}
+	/*
+		printf = func(format string, a ...interface{}) (n int, err error) {
+			stdout := new(bytes.Buffer)
+			fmt.Printf("%v", a)
+			fmt.Printf("\n%v", format)
+			fmt.Printf("\n%v", stdout)
+			return fmt.Fprintf(stdout, format, a)
+		}
+	*/
+	// run test
+	retCode := m.Run()
+	// teardown functions
+	os.RemoveAll(testDir)
+	os.Exit(retCode)
+}
+
+func TestSetupDir(t *testing.T) {
+	os.RemoveAll(testDir)
+
+	setupDir(testDir)
+	_, err := os.Stat(testFilePath)
+	if err != nil {
+		t.Errorf("could not create %s in %s", metaFile, testDir)
+	}
+}
+
+func TestGetMeta(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	getMeta("str", mockDir, stdout)
+	expected := []byte("fuga")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("bool", mockDir, stdout)
+	expected = []byte("true")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("int", mockDir, stdout)
+	expected = []byte("1")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("float", mockDir, stdout)
+	expected = []byte("1.5")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("obj", mockDir, stdout)
+	expected = []byte("{\"ccc\":\"ddd\",\"momo\":{\"toke\":\"toke\"}}")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary", mockDir, stdout)
+	expected = []byte("[\"aaa\",\"bbb\"]")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("nu", mockDir, stdout)
+	expected = []byte("null")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+}
+
+func TestSetMeta_bool(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("bool", "true", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"bool\":true}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+func TestSetMeta_number(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("int", "10", testDir)
+	setMeta("float", "15.5", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"float\":15.5,\"int\":10}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_string(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("str", "val", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"str\":\"val\"}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_array(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("array[]", "arg", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"array\":[\"arg\"]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_array_with_index(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("array[1]", "arg", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"array\":[null,\"arg\"]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+
+	setMeta("array[2]", "argarg", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"array\":[null,\"arg\",\"argarg\"]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_array_with_index_to_string(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("array[1]", "arg", testDir)
+	setMeta("array", "str", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"array\":\"str\"}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_object(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("foo.bar", "baz", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"foo\":{\"bar\":\"baz\"}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+
+	setMeta("foo.bar.baz", "piyo", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":{\"bar\":{\"baz\":\"piyo\"}}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_object_to_string(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("foo.bar", "baz", testDir)
+	setMeta("foo", "baz", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"foo\":\"baz\"}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+}
+
+func TestSetMeta_array_with_object(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("foo[1].bar", "baz", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"foo\":[null,{\"bar\":\"baz\"}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+
+	setMeta("foo.bar[1]", "baz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":{\"bar\":[null,\"baz\"]}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+
+	setMeta("foo[1].bar[1]", "baz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[null,{\"bar\":[null,\"baz\"]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(out))
+	}
+
+}

--- a/meta_test.go
+++ b/meta_test.go
@@ -15,19 +15,9 @@ const mockDir = "./mock"
 func TestMain(m *testing.M) {
 	// setup functions
 	setupDir(testDir)
-	//readFile = func(filename string) ([]byte, error) { return ioutil.ReadFile("./test/test.json") }
 	writeFile = func(filename string, data []byte, perm os.FileMode) error {
 		return ioutil.WriteFile(testFilePath, data, 0666)
 	}
-	/*
-		printf = func(format string, a ...interface{}) (n int, err error) {
-			stdout := new(bytes.Buffer)
-			fmt.Printf("%v", a)
-			fmt.Printf("\n%v", format)
-			fmt.Printf("\n%v", stdout)
-			return fmt.Fprintf(stdout, format, a)
-		}
-	*/
 	// run test
 	retCode := m.Run()
 	// teardown functions
@@ -93,6 +83,15 @@ func TestGetMeta(t *testing.T) {
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected[:]), string(stdout.Bytes()[:]))
+	}
+}
+
+func TestGetMetaWithFailuer(t *testing.T) {
+	// meta.json does not exist
+	stdout := new(bytes.Buffer)
+	err := getMeta("str", "not_exist", stdout)
+	if err == nil {
+		t.Fatalf("error should be occured")
 	}
 }
 

--- a/mock/meta.json
+++ b/mock/meta.json
@@ -1,0 +1,1 @@
+{"str":"fuga","bool":true,"int":1,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb"], "nu":null}


### PR DESCRIPTION
To enable to pass the data between build in the same event, `meta-cli` provides simple interface for reading/writing values as command line client.
This `meta-cli` is called in build container and save meta to temporary file.
Before finish the build, this meta put to data store via API call.
This stored meta will be loaded when setup next build.

Detail is https://github.com/screwdriver-cd/screwdriver/issues/293.
Based on https://github.com/screwdriver-cd/screwdriver/issues/293, this PR provides meta-cli implementation.
"Stretch (gold bar): ..." is not implemented this PR yet.

This works like following:
```
$ go build
$ ./meta-cli set foo[2].bar[1] baz
$ ./meta-cli get foo
[null,null,{"bar":[null,"baz"]}]
```

I think this meta-cli is called in [launcher](https://github.com/screwdriver-cd/launcher) so I also updating launcher code.
https://github.com/screwdriver-cd/launcher/pull/108