### PR TITLE
fix(293): meta get enable to get map and array meta

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -58,30 +58,30 @@ func getMeta(key string, metaSpace string, output io.Writer) error {
 
 func fetchMetaValue(key string, meta interface{}) (string, interface{}) {
 	var result interface{}
-	for position, char := range key {
+	for current, char := range key {
 		if string([]rune{char}) == "[" {
 			// Value is array with index
 			var i int
-			for i = position + 1; ; i++ {
+			for i = current + 1; ; i++ {
 				_, err := strconv.Atoi(string(key[i])) // Check the next char is integer
 				if err != nil {
 					break
 				}
 			}
-			metaIndex, _ := strconv.Atoi(key[position+1 : i]) // e.g. if array[10], get "10"
-			shortenKey := key[i+1:]                           // Remove bracket[num] from key
+			metaIndex, _ := strconv.Atoi(key[current+1 : i]) // e.g. if array[10], get "10"
+			shortenKey := key[i+1:]                          // Remove bracket[num] from key
 			metaValue := reflect.ValueOf(meta)
 			// convert type interface -> Value -> map[string]interface{}
 			metaMap := make(map[string]interface{})
 			if metaValue.Kind() == reflect.Map {
-				for _, k := range metaValue.MapKeys() {
-					pk, _ := k.Interface().(string)
-					metaMap[pk] = metaValue.MapIndex(k).Interface()
+				for _, keyValue := range metaValue.MapKeys() {
+					keyString, _ := keyValue.Interface().(string)
+					metaMap[keyString] = metaValue.MapIndex(keyValue).Interface()
 				}
 			} else {
 				return "", nil
 			}
-			childMeta := metaMap[key[0:position]]
+			childMeta := metaMap[key[0:current]]
 			childMetaValue := reflect.ValueOf(childMeta)
 			// convert type interface{} -> Value -> []interface{}
 			childMetaSlice := make([]interface{}, childMetaValue.Len())
@@ -100,9 +100,9 @@ func fetchMetaValue(key string, meta interface{}) (string, interface{}) {
 			childKey := strings.Split(key, ".")[0]
 			shortenKey := strings.Join(strings.Split(key, ".")[1:], ".")
 			if metaValue.Kind() == reflect.Map {
-				for _, k := range metaValue.MapKeys() {
-					pk, _ := k.Interface().(string)
-					metaValueMap[pk] = metaValue.MapIndex(k).Interface()
+				for _, keyValue := range metaValue.MapKeys() {
+					keyString, _ := keyValue.Interface().(string)
+					metaValueMap[keyString] = metaValue.MapIndex(keyValue).Interface()
 				}
 				if len(childKey) != 0 {
 					return fetchMetaValue(shortenKey, metaValueMap[childKey])

--- a/meta_test.go
+++ b/meta_test.go
@@ -72,14 +72,87 @@ func TestGetMeta(t *testing.T) {
 	}
 
 	stdout = new(bytes.Buffer)
+	getMeta("obj.ccc", mockDir, stdout)
+	expected = []byte("ddd")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("obj.momo", mockDir, stdout)
+	expected = []byte("{\"toke\":\"toke\"}")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
 	getMeta("ary", mockDir, stdout)
-	expected = []byte("[\"aaa\",\"bbb\"]")
+	expected = []byte("[\"aaa\",\"bbb\",{\"ccc\":{\"ddd\":[1,2,3]}}]")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary[0]", mockDir, stdout)
+	expected = []byte("aaa")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary[2]", mockDir, stdout)
+	expected = []byte("{\"ccc\":{\"ddd\":[1,2,3]}}")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary[2].ccc", mockDir, stdout)
+	expected = []byte("{\"ddd\":[1,2,3]}")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary[2].ccc.ddd", mockDir, stdout)
+	expected = []byte("[1,2,3]")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	getMeta("ary[2].ccc.ddd[1]", mockDir, stdout)
+	expected = []byte("2")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("nu", mockDir, stdout)
+	expected = []byte("null")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	// The key does not exist in meta.json
+	stdout = new(bytes.Buffer)
+	getMeta("notexist", mockDir, stdout)
+	expected = []byte("null")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	// It makes golang zero-value
+	stdout = new(bytes.Buffer)
+	getMeta("ary[]", mockDir, stdout)
+	expected = []byte("aaa")
+	if bytes.Compare(expected, stdout.Bytes()) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+
+	// The key does not exist in meta.json
+	stdout = new(bytes.Buffer)
+	getMeta("ary.aaa.bbb.ccc.ddd[10]", mockDir, stdout)
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))

--- a/mock/meta.json
+++ b/mock/meta.json
@@ -1,1 +1,1 @@
-{"str":"fuga","bool":true,"int":1,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb"], "nu":null}
+{"str":"fuga","bool":true,"int":1,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb",{"ccc":{"ddd":[1,2,3]}}], "nu":null}


### PR DESCRIPTION
### Before
`meta get` could not get nested value like following:
```
sh-3.2$ ./meta set foo.bar baz
sh-3.2$ ./meta get foo && echo
{"bar":"baz"}
sh-3.2$ ./meta get foo.bar && echo
null
```

### After
I fixed to enable to get such value like following:
```
$ ./meta set foo.bar baz                                                                                                                                           
$ ./meta get foo                                                                                                                                                   
{"bar":"baz"}%         
$ ./meta get foo.bar                                                                                                                                                                                                                                                                                                                         
baz%
```

and

```
$ ./meta set foo[2].bar baz
$ ./meta get foo                                                                                                                                                      
[null,null,{"bar":"baz"}]%
$ ./meta get foo[2]
{"bar":"baz"}%
$./meta get foo[2].bar
baz
```


I have no good idea about function naming😥 
If you have idea, please teach me on comment.

Related: https://github.com/screwdriver-cd/screwdriver/issues/293#issuecomment-286246365