### PR TITLE
fix(543): fix to not overwrite object and fix array-object meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *.so
 meta-cli
+meta
 
 # Folders
 _obj

--- a/meta.go
+++ b/meta.go
@@ -244,6 +244,11 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}) (
 			if previousMetaMap[keyHead] == nil {
 				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap)
 			} else {
+				// copy previous object only if it is map
+				previousObj := convertInterfaceToMap(previousMetaMap[keyHead])
+				if len(previousObj) != 0 {
+					obj = previousObj
+				}
 				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap[keyHead])
 			}
 			obj[childKey] = tmpValue

--- a/meta.go
+++ b/meta.go
@@ -236,13 +236,18 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}) (
 			}
 		} else if string([]rune{char}) == "." {
 			// Value is object
+			keyHead := key[0:current]   // e.g. aaa.bbb -> aaa
 			childKey := key[current+1:] // e.g. aaa.bbb -> bbb
-			key = key[0:current]        // e.g. aaa.bbb -> aaa
 			obj := make(map[string]interface{})
+			var tmpValue interface{}
 			previousMetaMap := convertInterfaceToMap(previousMeta)
-			childKey, tmpValue := setMetaValueRecursive(childKey, value, previousMetaMap[key])
+			if previousMetaMap[keyHead] == nil {
+				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap)
+			} else {
+				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap[keyHead])
+			}
 			obj[childKey] = tmpValue
-			return key, obj
+			return keyHead, obj
 		}
 	}
 	// Value is int

--- a/meta_test.go
+++ b/meta_test.go
@@ -283,12 +283,22 @@ func TestSetMeta_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
+	setMeta("foo.barbar", "bazbaz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":{\"bar\":\"baz\",\"barbar\":\"bazbaz\"}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
 	setMeta("foo.bar.baz", "piyo", testDir)
 	out, err = exec.Command("cat", testFilePath).Output()
 	if err != nil {
 		t.Fatal("Meta file did not create.")
 	}
-	expected = []byte("{\"foo\":{\"bar\":{\"baz\":\"piyo\"}}}")
+	expected = []byte("{\"foo\":{\"bar\":{\"baz\":\"piyo\"},\"barbar\":\"bazbaz\"}}")
 	if bytes.Compare(expected, out) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
@@ -400,6 +410,41 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatal("Meta file did not create.")
 	}
 	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\",null,{\"baz\":[null,\"qux\"]}]},{\"bar\":[\"ba\",\"baz\",\"bazbaz\",{\"baz\":[\"quxqux\",\"qux\"]}]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+}
+
+func TestSetMeta_object_with_array(t *testing.T) {
+	setupDir(testDir)
+	os.Remove(testFilePath)
+
+	setMeta("foo.bar[1]", "baz", testDir)
+	out, err := exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected := []byte("{\"foo\":{\"bar\":[null,\"baz\"]}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo.bar[0]", "baz0", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":{\"bar\":[\"baz0\",\"baz\"]}}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo.barbar[2]", "bazbaz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":{\"bar\":[\"baz0\",\"baz\"],\"barbar\":[null,null,\"bazbaz\"]}}")
 	if bytes.Compare(expected, out) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -343,6 +343,66 @@ func TestSetMeta_array_with_object(t *testing.T) {
 	if bytes.Compare(expected, out) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
+
+	setMeta("foo[0].bar[1]", "baz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\"]},{\"bar\":[null,\"baz\"]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo[1].bar[0]", "ba", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\"]},{\"bar\":[\"ba\",\"baz\"]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo[1].bar[2]", "bazbaz", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\"]},{\"bar\":[\"ba\",\"baz\",\"bazbaz\"]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo[1].bar[3].baz[1]", "qux", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\"]},{\"bar\":[\"ba\",\"baz\",\"bazbaz\",{\"baz\":[null,\"qux\"]}]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo[1].bar[3].baz[0]", "quxqux", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\"]},{\"bar\":[\"ba\",\"baz\",\"bazbaz\",{\"baz\":[\"quxqux\",\"qux\"]}]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+
+	setMeta("foo[0].bar[3].baz[1]", "qux", testDir)
+	out, err = exec.Command("cat", testFilePath).Output()
+	if err != nil {
+		t.Fatal("Meta file did not create.")
+	}
+	expected = []byte("{\"foo\":[{\"bar\":[null,\"baz\",null,{\"baz\":[null,\"qux\"]}]},{\"bar\":[\"ba\",\"baz\",\"bazbaz\",{\"baz\":[\"quxqux\",\"qux\"]}]}]}")
+	if bytes.Compare(expected, out) != 0 {
+		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
 }
 
 func TestValidateMetaKeyWithAccept(t *testing.T) {
@@ -483,14 +543,6 @@ func TestIndexOfFirstRightBracket(t *testing.T) {
 	key = "foo[10]"
 	i = indexOfFirstRightBracket(key)
 	expected = 6
-
-	if i != expected {
-		t.Fatalf("Expected '%d' but '%d'", expected, i)
-	}
-
-	key = "foo[123].bar[10].baz"
-	i = indexOfFirstRightBracket(key)
-	expected = 7
 
 	if i != expected {
 		t.Fatalf("Expected '%d' but '%d'", expected, i)


### PR DESCRIPTION
## Context
When trying to add in a new key, the object gets overridden. This happened like below:
```
shared:
    image: node:6
jobs:
    main:
        steps:
            - test: meta set foo.a true
            - test1: meta set foo.b true
            - test3: echo `meta get foo`
```
The actual output of the echo is `"{ "b" : true }"`, and the expected output would be `"{ "a": true, "b": true}"`

Also, when trying to update array-object meta, the array is overwritten.
```
% meta set foo[0].bar[1] aaa
% meta set foo[0].bar[0] bbb
% meta get foo[0]
{"bar":["bbb"]}
```
The expected output would be `{"bar":["bbb", "aaa"]}`.

## Object
Fixed these bug and added test for these pattern.
`% go test` is passed and the above example is also worked.

First commit fixed array-object bug, second commit fixed object overwrite bug.

```
% ./meta-cli set foo.a true 
% ./meta-cli set foo.b true    
% ./meta-cli get foo  
{"a":true,"b":true}%
```

## Misc.
Related: https://github.com/screwdriver-cd/screwdriver/issues/543