### PR TITLE
fix: metaFile does not include json

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -30,7 +30,7 @@ var rightBracketRegExp = regexp.MustCompile(`\[(.*?)\]`)
 
 // getMeta prints meta value from file based on key
 func getMeta(key string, metaSpace string, metaFile string, output io.Writer) error {
-	metaFilePath := metaSpace + "/" + metaFile
+	metaFilePath := metaSpace + "/" + metaFile + ".json"
 
 	_, err := stat(metaFilePath)
 	// Setup directory if it does not exist
@@ -162,7 +162,7 @@ func fetchMetaValue(key string, meta interface{}) (string, interface{}) {
 
 // setMeta stores meta to file with key and value
 func setMeta(key string, value string, metaSpace string, metaFile string) error {
-	metaFilePath := metaSpace + "/" + metaFile
+	metaFilePath := metaSpace + "/" + metaFile + ".json"
 	var previousMeta map[string]interface{}
 
 	_, err := stat(metaFilePath)
@@ -291,7 +291,7 @@ func setupDir(metaSpace string, metaFile string) error {
 	if err != nil {
 		return err
 	}
-	err = writeFile(metaSpace+"/"+metaFile, []byte(""), 0666)
+	err = writeFile(metaSpace+"/"+metaFile+".json", []byte(""), 0666)
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func main() {
 		cli.StringFlag{
 			Name:        "external, e",
 			Usage:       "External pipeline meta",
-			Value:       "meta.json",
+			Value:       "meta",
 			Destination: &metaFile,
 		},
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 )
 
-const testFile = "meta.json"
+const testFile = "meta"
 const testDir = "./_test"
-const testFilePath = testDir + "/" + testFile
+const testFilePath = testDir + "/" + testFile + ".json"
 const mockDir = "./mock"
-const externalFile = "sd@123:component.json"
-const externalFilePath = testDir + "/" + externalFile
-const doesNotExistFile = "woof.json"
+const externalFile = "sd@123:component"
+const externalFilePath = testDir + "/" + externalFile + ".json"
+const doesNotExistFile = "woof"
 
 func TestMain(m *testing.M) {
 	// setup functions
@@ -31,7 +31,7 @@ func TestSetupDir(t *testing.T) {
 	setupDir(testDir, testFile)
 	_, err := os.Stat(testFilePath)
 	if err != nil {
-		t.Errorf("could not create %s in %s", testFile, testDir)
+		t.Errorf("could not create %s in %s", testFilePath, testDir)
 	}
 }
 


### PR DESCRIPTION
So `meta get foo --external sd@123:component` is not working in `beta`.
I went inside the container and the file `sd@123:component.json` is actually there. However, it's not able to read it because the flag doesn't include `json`. We need to add it. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/771