### PR TITLE
fix: Can only meta set current running build meta

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -165,6 +165,10 @@ func setMeta(key string, value string, metaSpace string, metaFile string) error 
 	metaFilePath := metaSpace + "/" + metaFile + ".json"
 	var previousMeta map[string]interface{}
 
+	if metaFile != "meta" {
+		return errors.New("Can only meta set current build meta")
+	}
+
 	_, err := stat(metaFilePath)
 	// Not exist directory
 	if err != nil {

--- a/meta_test.go
+++ b/meta_test.go
@@ -39,21 +39,16 @@ func TestExternalMetaFile(t *testing.T) {
 	setupDir(testDir, externalFile)
 	os.Remove(externalFilePath)
 
-	// Test set
-	setMeta("str", "val", testDir, externalFile)
-	out, err := exec.Command("cat", externalFilePath).Output()
-	if err != nil {
-		t.Fatal("Meta file did not create.")
-	}
-	expected := []byte("{\"str\":\"val\"}")
-	if bytes.Compare(expected, out) != 0 {
-		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	// Test set (meta file is not meta.json, should fail)
+	err := setMeta("str", "val", testDir, externalFile)
+	if err == nil {
+		t.Fatalf("error should be occured")
 	}
 
 	// Test get
 	stdout := new(bytes.Buffer)
 	getMeta("str", mockDir, externalFile, stdout)
-	expected = []byte("meow")
+	expected := []byte("meow")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}


### PR DESCRIPTION
## Context

Users should only be able to `meta get` from external builds. If they try to `meta set` an external build, the build should fail.

## Objective

This PR checks if the file that we are trying to `meta set` is the current build meta or not.

## Related Links
https://github.com/screwdriver-cd/screwdriver/issues/771