### PR TITLE
fix(839): use Decoder instead of json.Unmarshal

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +50,10 @@ func getMeta(key string, metaSpace string, metaFile string, output io.Writer) er
 	}
 
 	var metaInterface map[string]interface{}
-	err = json.Unmarshal(metaJson, &metaInterface)
+	// for Unmarshal integer as integer, not float64
+	decoder := json.NewDecoder(bytes.NewReader(metaJson))
+	decoder.UseNumber()
+	err = decoder.Decode(&metaInterface)
 	if err != nil {
 		return err
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -82,7 +82,7 @@ func TestGetMeta(t *testing.T) {
 
 	stdout = new(bytes.Buffer)
 	getMeta("int", mockDir, testFile, stdout)
-	expected = []byte("1")
+	expected = []byte("1234567")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
@@ -117,7 +117,7 @@ func TestGetMeta(t *testing.T) {
 
 	stdout = new(bytes.Buffer)
 	getMeta("ary", mockDir, testFile, stdout)
-	expected = []byte("[\"aaa\",\"bbb\",{\"ccc\":{\"ddd\":[1,2,3]}}]")
+	expected = []byte("[\"aaa\",\"bbb\",{\"ccc\":{\"ddd\":[1234567,2,3]}}]")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
@@ -131,21 +131,21 @@ func TestGetMeta(t *testing.T) {
 
 	stdout = new(bytes.Buffer)
 	getMeta("ary[2]", mockDir, testFile, stdout)
-	expected = []byte("{\"ccc\":{\"ddd\":[1,2,3]}}")
+	expected = []byte("{\"ccc\":{\"ddd\":[1234567,2,3]}}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("ary[2].ccc", mockDir, testFile, stdout)
-	expected = []byte("{\"ddd\":[1,2,3]}")
+	expected = []byte("{\"ddd\":[1234567,2,3]}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
 	getMeta("ary[2].ccc.ddd", mockDir, testFile, stdout)
-	expected = []byte("[1,2,3]")
+	expected = []byte("[1234567,2,3]")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}

--- a/mock/meta.json
+++ b/mock/meta.json
@@ -1,1 +1,1 @@
-{"str":"fuga","bool":true,"int":1,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb",{"ccc":{"ddd":[1,2,3]}}], "nu":null}
+{"str":"fuga","bool":true,"int":1234567,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb",{"ccc":{"ddd":[1234567,2,3]}}], "nu":null}


### PR DESCRIPTION
## Context
When we do meta get a number >6 digits, it will convert to +e06
For example,
```
$ meta set build_version_1 1234567
$ meta get build_version_1`
1.234567e+06
```

A meta value is converted to float64 from interface in spite of an integer is load from a json file. It seems to be specification of json.Unmarshal().

## Objective
We use "Decoder" instead of json.Unmarshal(). "Decoder" has [UseNumber() function](https://golang.org/src/encoding/json/stream.go?s=800:831#L26). It works as following:
> UseNumber causes the Decoder to unmarshal a number into an interface{} as a Number instead of as a float64.

Test is also modified.

Reference: https://github.com/golang/go/issues/5562
Related: https://github.com/screwdriver-cd/screwdriver/issues/839