### PR TITLE
fix(habitat): Download the right dependencies

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -13,7 +13,9 @@ pkg_bin_dirs=(bin)
 
 # Scaffolding based on https://github.com/habitat-sh/core-plans/tree/master/scaffolding-go
 scaffolding_go_base_path="github.com/screwdriver-cd"
-scaffolding_go_build_deps=()
+scaffolding_go_build_deps=(
+    gopkg.in/urfave/cli.v1
+)
 
 # Extract the version from the last published GitHub release
 pkg_version() {


### PR DESCRIPTION
I forgot to include this in the dependency list.  See failed build here: https://bldr.habitat.sh/#/pkgs/screwdriver-cd/meta-cli/builds/911133979712364544