### PR TITLE
feat(964): allow meta keys including dash (-)

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -32,7 +32,7 @@ var writeFile = ioutil.WriteFile
 var readFile = ioutil.ReadFile
 var fprintf = fmt.Fprintf
 
-var metaKeyValidator = regexp.MustCompile(`^\w+(((\[\]|\[(0|[1-9]\d*)\]))?(\.\w+)*)*$`)
+var metaKeyValidator = regexp.MustCompile(`^(\w+(-*\w+)*)+(((\[\]|\[(0|[1-9]\d*)\]))?(\.(\w+(-*\w+)*)+)*)*$`)
 var rightBracketRegExp = regexp.MustCompile(`\[(.*?)\]`)
 
 // getMeta prints meta value from file based on key

--- a/mock/meta.json
+++ b/mock/meta.json
@@ -1,1 +1,1 @@
-{"str":"fuga","bool":true,"int":1234567,"float":1.5,"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb",{"ccc":{"ddd":[1234567,2,3]}}], "nu":null}
+{"str":"fuga","bool":true,"int":1234567,"float":1.5,"foo":{"bar-baz":"dashed-key"},"obj":{"ccc":"ddd","momo":{"toke":"toke"}},"ary":["aaa","bbb",{"ccc":{"ddd":[1234567,2,3]}}], "nu":null}


### PR DESCRIPTION
## Context

Meta keys including dash (`-`) is currently not allowed. This PR can allow it.

Meta key examples:
- OK
  - `foo.bar-baz`
  - `fo-o.bar-baz`
  - `foo[1].bar-baz[2]`
- NG
  - `foo.-bar-baz`
  - `foo.bar-baz-`
  - `foo[1].bar-baz-[2]`

## References

- https://github.com/screwdriver-cd/screwdriver/issues/964