### PR TITLE
fix: JSON unmarshall error

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -304,7 +304,7 @@ func setupDir(metaSpace string, metaFile string) error {
 	if err != nil {
 		return err
 	}
-	err = writeFile(metaSpace+"/"+metaFile+".json", []byte(""), 0666)
+	err = writeFile(metaSpace+"/"+metaFile+".json", []byte("{}"), 0666)
 	if err != nil {
 		return err
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -26,12 +26,23 @@ func TestMain(m *testing.M) {
 }
 
 func TestSetupDir(t *testing.T) {
+	var err error
+	var data []byte
+
 	os.RemoveAll(testDir)
 
 	setupDir(testDir, testFile)
-	_, err := os.Stat(testFilePath)
+	_, err = os.Stat(testFilePath)
 	if err != nil {
 		t.Errorf("could not create %s in %s", testFilePath, testDir)
+	}
+
+	data, err = ioutil.ReadFile(testFilePath)
+	if err != nil {
+		t.Errorf("could not read %s in %s", testFilePath, testDir)
+	}
+	if string(data[:]) != "{}"  {
+		t.Errorf("%s does not have an empty JSON object: %v", testFilePath, string(data[:]))
 	}
 }
 


### PR DESCRIPTION
This fixes screwdriver-cd/screwdriver#1193.
The cause of the issue is writing empty string to `meta.json` if there is no `meta.json` yet, so writing an empty object `{}` resolves this issue.