### PR TITLE
feat: add go.mod for Go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/screwdriver-cd/meta-cli
+
+go 1.12
+
+require gopkg.in/urfave/cli.v1 v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=

--- a/meta_test.go
+++ b/meta_test.go
@@ -41,7 +41,7 @@ func TestSetupDir(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not read %s in %s", testFilePath, testDir)
 	}
-	if string(data[:]) != "{}"  {
+	if string(data[:]) != "{}" {
 		t.Errorf("%s does not have an empty JSON object: %v", testFilePath, string(data[:]))
 	}
 }


### PR DESCRIPTION
## Context

Go currently supports the modules mechanism based on a `go.mod` manifest for dependencies specification and management.

## Objective
PR adds a `go.mod` files so that the code can be built in any directory, not necessarily under the `$GOPATH`-based directory. 

PR also fixes a `gofmt` deviation currently present in the master version (when using `go1.12.6` version):
```
$ gofmt -d .
diff -u meta_test.go.orig meta_test.go
--- meta_test.go.orig	2019-07-09 11:04:46.000000000 +0200
+++ meta_test.go	2019-07-09 11:04:46.000000000 +0200
@@ -41,7 +41,7 @@
 	if err != nil {
 		t.Errorf("could not read %s in %s", testFilePath, testDir)
 	}
-	if string(data[:]) != "{}"  {
+	if string(data[:]) != "{}" {
 		t.Errorf("%s does not have an empty JSON object: %v", testFilePath, string(data[:]))
 	}
 }
```

## References
https://github.com/golang/go/wiki/Modules

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
