### PR TITLE
replace 'go get' with 'go mod verify'

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,9 +9,9 @@ jobs:
     main:
         requires: [~pr, ~commit]
         steps:
-            - get: go get -v ./...
+            - modverify: go mod verify
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - gofmt: gofmt -d .
             - test: go test ./...
             - build: go build -a -o $SD_ARTIFACTS_DIR/meta
 
@@ -19,7 +19,6 @@ jobs:
         requires: [main]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - get: go get -v ./...
             - tag: ./ci/git-tag.sh
             - release: "curl -sL https://git.io/goreleaser | bash"
         secrets:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - modverify: go mod verify
             - vet: go vet ./...
-            - gofmt: gofmt -d .
+            - gofmt: (! gofmt -d . | grep '^')
             - test: go test ./...
             - build: go build -a -o $SD_ARTIFACTS_DIR/meta
 


### PR DESCRIPTION
PR replaces no longer needed / redundant `go get ./...` invocation with a new `modverify` step running `go mod verify`.  It also simplifies the `gofmt` command in the corresponding step: it is useless to format the data (with `-w` flag) in the build since formatting is for humans, the compiler doesn't care much about whitespaces and so on 😄 On the other hand, I believe we should fail the build if the contributor hasn't done the proper formatting of the modified code.

@tk3fftk 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
