### PR TITLE
Allow json values in get/set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ GLOBAL OPTIONS:
    --version, -v               print the version
 
 COPYRIGHT:
-   (c) 2017-unknown Yahoo Inc.
+   (c) 2017 Yahoo Inc.
 $ ./meta set aaa bbb
 $ ./meta get aaa
 bbb
 $ ./meta set foo[2].bar[1] baz
 [null,null,{"bar":[null,"baz"]}]
 $ ./meta set foo '{"bar": "baz", "buz": 123}' --json-value
-$ ./meta-cli get foo --json-value
+$ ./meta get foo --json-value
 {"bar":"baz","buz":123}
 $ ./meta get foo.bar
 baz

--- a/README.md
+++ b/README.md
@@ -27,17 +27,26 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --meta-space value  Location of meta temporarily (default: "/sd/meta")
-   --help, -h          show help
-   --version, -v       print the version
+   --meta-space value          Location of meta temporarily (default: "/sd/meta")
+   --external value, -e value  External pipeline meta (default: "meta")
+   --json-value, -j            Treat value as json
+   --help, -h                  show help
+   --version, -v               print the version
 
 COPYRIGHT:
-   (c) 2017 Yahoo Inc.
+   (c) 2017-unknown Yahoo Inc.
 $ ./meta set aaa bbb
 $ ./meta get aaa
 bbb
 $ ./meta set foo[2].bar[1] baz
 [null,null,{"bar":[null,"baz"]}]
+$ ./meta set foo '{"bar": "baz", "buz": 123}' --json-value
+$ ./meta-cli get foo --json-value
+{"bar":"baz","buz":123}
+$ ./meta get foo.bar
+baz
+$ ./meta get foo.bar --json-value
+"baz"
 ```
 
 ## Testing

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/screwdriver-cd/meta-cli
 
 go 1.12
 
-require gopkg.in/urfave/cli.v1 v1.20.0
+require (
+	github.com/stretchr/testify v1.4.0
+	gopkg.in/urfave/cli.v1 v1.20.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/meta.go
+++ b/meta.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"reflect"
 	"regexp"
@@ -36,7 +37,7 @@ var metaKeyValidator = regexp.MustCompile(`^(\w+(-*\w+)*)+(((\[\]|\[(0|[1-9]\d*)
 var rightBracketRegExp = regexp.MustCompile(`\[(.*?)\]`)
 
 // getMeta prints meta value from file based on key
-func getMeta(key string, metaSpace string, metaFile string, output io.Writer) error {
+func getMeta(key string, metaSpace string, metaFile string, output io.Writer, jsonValue bool) error {
 	metaFilePath := metaSpace + "/" + metaFile + ".json"
 
 	_, err := stat(metaFilePath)
@@ -73,7 +74,12 @@ func getMeta(key string, metaSpace string, metaFile string, output io.Writer) er
 	case nil:
 		fprintf(output, "null")
 	default:
-		fprintf(output, "%v", result)
+		if jsonValue {
+			resultJSON, _ := json.Marshal(result)
+			fprintf(output, "%v", string(resultJSON))
+		} else {
+			fprintf(output, "%v", result)
+		}
 	}
 
 	return nil
@@ -170,7 +176,7 @@ func fetchMetaValue(key string, meta interface{}) (string, interface{}) {
 }
 
 // setMeta stores meta to file with key and value
-func setMeta(key string, value string, metaSpace string, metaFile string) error {
+func setMeta(key string, value string, metaSpace string, metaFile string, jsonValue bool) error {
 	metaFilePath := metaSpace + "/" + metaFile + ".json"
 	var previousMeta map[string]interface{}
 
@@ -201,7 +207,7 @@ func setMeta(key string, value string, metaSpace string, metaFile string) error 
 		}
 	}
 
-	key, parsedValue := setMetaValueRecursive(key, value, previousMeta)
+	key, parsedValue := setMetaValueRecursive(key, value, previousMeta, jsonValue)
 	previousMeta[key] = parsedValue
 
 	resultJSON, err := json.Marshal(previousMeta)
@@ -214,7 +220,7 @@ func setMeta(key string, value string, metaSpace string, metaFile string) error 
 }
 
 // setMetaValueRecursive updates meta
-func setMetaValueRecursive(key string, value string, previousMeta interface{}) (string, interface{}) {
+func setMetaValueRecursive(key string, value string, previousMeta interface{}, jsonValue bool) (string, interface{}) {
 	for current, char := range key {
 		if string([]rune{char}) == "[" {
 			nextChar := key[current+1]
@@ -222,7 +228,7 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}) (
 				// Value is array
 				var metaValue [1]interface{}
 				key = key[0:current] + key[current+2:] // Remove bracket[] from key
-				key, metaValue[0] = setMetaValueRecursive(key, value, previousMeta)
+				key, metaValue[0] = setMetaValueRecursive(key, value, previousMeta, jsonValue)
 				return key, metaValue
 			}
 
@@ -239,14 +245,14 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}) (
 			// previousMetaMap[keyHead] is empty or string, create array with null except value of argument
 			if previousMetaMap[keyHead] == nil || reflect.ValueOf(previousMetaMap[keyHead]).Kind() == reflect.String {
 				metaValue = make([]interface{}, metaIndex+1)
-				key, metaValue[metaIndex] = setMetaValueRecursive(key, value, previousMetaMap[keyHead])
+				key, metaValue[metaIndex] = setMetaValueRecursive(key, value, previousMetaMap[keyHead], jsonValue)
 			} else {
 				if metaIndex+1 > previousMetaValue.Len() {
 					metaValue = make([]interface{}, metaIndex+1)
-					key, metaValue[metaIndex] = setMetaValueRecursive(key, value, nil)
+					key, metaValue[metaIndex] = setMetaValueRecursive(key, value, nil, jsonValue)
 				} else {
 					metaValue = make([]interface{}, previousMetaValue.Len())
-					key, metaValue[metaIndex] = setMetaValueRecursive(key, value, previousMetaValue.Index(metaIndex).Interface())
+					key, metaValue[metaIndex] = setMetaValueRecursive(key, value, previousMetaValue.Index(metaIndex).Interface(), jsonValue)
 				}
 			}
 			// Insert previous values to metaValue[] when previousMetaValue type is slice except new value
@@ -266,17 +272,29 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}) (
 			var tmpValue interface{}
 			previousMetaMap := convertInterfaceToMap(previousMeta)
 			if previousMetaMap[keyHead] == nil {
-				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap)
+				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap, jsonValue)
 			} else {
 				// copy previous object only if it is map
 				previousObj := convertInterfaceToMap(previousMetaMap[keyHead])
 				if len(previousObj) != 0 {
 					obj = previousObj
 				}
-				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap[keyHead])
+				childKey, tmpValue = setMetaValueRecursive(childKey, value, previousMetaMap[keyHead], jsonValue)
 			}
 			obj[childKey] = tmpValue
 			return keyHead, obj
+		}
+	}
+	if jsonValue {
+		char := value[0]
+		switch char {
+		case '{', '[', '"':
+			var objectValue interface{}
+			if err := json.Unmarshal([]byte(value), &objectValue); err == nil {
+				return key, objectValue
+			} else {
+				log.Panic(err)
+			}
 		}
 	}
 	// Value is int
@@ -345,6 +363,7 @@ func main() {
 
 	var metaSpace string
 	var metaFile string
+	var jsonValue bool
 
 	app := cli.NewApp()
 	app.Name = "meta-cli"
@@ -372,6 +391,11 @@ func main() {
 			Value:       "meta",
 			Destination: &metaFile,
 		},
+		cli.BoolFlag{
+			Name:        "json-value, j",
+			Usage:       "Treat value as json",
+			Destination: &jsonValue,
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -386,7 +410,7 @@ func main() {
 				if valid := validateMetaKey(key); valid == false {
 					failureExit(errors.New("Meta key validation error"))
 				}
-				err := getMeta(key, metaSpace, metaFile, os.Stdout)
+				err := getMeta(key, metaSpace, metaFile, os.Stdout, jsonValue)
 				if err != nil {
 					failureExit(err)
 				}
@@ -407,7 +431,7 @@ func main() {
 				if valid := validateMetaKey(key); valid == false {
 					failureExit(errors.New("Meta key validation error"))
 				}
-				err := setMeta(key, val, metaSpace, metaFile)
+				err := setMeta(key, val, metaSpace, metaFile, jsonValue)
 				if err != nil {
 					failureExit(err)
 				}

--- a/meta.go
+++ b/meta.go
@@ -286,15 +286,11 @@ func setMetaValueRecursive(key string, value string, previousMeta interface{}, j
 		}
 	}
 	if jsonValue {
-		char := value[0]
-		switch char {
-		case '{', '[', '"':
-			var objectValue interface{}
-			if err := json.Unmarshal([]byte(value), &objectValue); err == nil {
-				return key, objectValue
-			} else {
-				log.Panic(err)
-			}
+		var objectValue interface{}
+		if err := json.Unmarshal([]byte(value), &objectValue); err == nil {
+			return key, objectValue
+		} else {
+			log.Panic(err)
 		}
 	}
 	// Value is int

--- a/meta_test.go
+++ b/meta_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -51,14 +53,14 @@ func TestExternalMetaFile(t *testing.T) {
 	os.Remove(externalFilePath)
 
 	// Test set (meta file is not meta.json, should fail)
-	err := setMeta("str", "val", testDir, externalFile)
+	err := setMeta("str", "val", testDir, externalFile, false)
 	if err == nil {
 		t.Fatalf("error should be occured")
 	}
 
 	// Test get
 	stdout := new(bytes.Buffer)
-	getMeta("str", mockDir, externalFile, stdout)
+	getMeta("str", mockDir, externalFile, stdout, false)
 	expected := []byte("meow")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
@@ -69,7 +71,7 @@ func TestGetMetaNoFile(t *testing.T) {
 	os.RemoveAll(testDir)
 
 	stdout := new(bytes.Buffer)
-	getMeta("woof", testDir, doesNotExistFile, stdout)
+	getMeta("woof", testDir, doesNotExistFile, stdout, false)
 	expected := []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
@@ -78,105 +80,105 @@ func TestGetMetaNoFile(t *testing.T) {
 
 func TestGetMeta(t *testing.T) {
 	stdout := new(bytes.Buffer)
-	getMeta("str", mockDir, testFile, stdout)
+	getMeta("str", mockDir, testFile, stdout, false)
 	expected := []byte("fuga")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("bool", mockDir, testFile, stdout)
+	getMeta("bool", mockDir, testFile, stdout, false)
 	expected = []byte("true")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("int", mockDir, testFile, stdout)
+	getMeta("int", mockDir, testFile, stdout, false)
 	expected = []byte("1234567")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("float", mockDir, testFile, stdout)
+	getMeta("float", mockDir, testFile, stdout, false)
 	expected = []byte("1.5")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("foo.bar-baz", mockDir, testFile, stdout)
+	getMeta("foo.bar-baz", mockDir, testFile, stdout, false)
 	expected = []byte("dashed-key")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("obj", mockDir, testFile, stdout)
+	getMeta("obj", mockDir, testFile, stdout, false)
 	expected = []byte("{\"ccc\":\"ddd\",\"momo\":{\"toke\":\"toke\"}}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("obj.ccc", mockDir, testFile, stdout)
+	getMeta("obj.ccc", mockDir, testFile, stdout, false)
 	expected = []byte("ddd")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("obj.momo", mockDir, testFile, stdout)
+	getMeta("obj.momo", mockDir, testFile, stdout, false)
 	expected = []byte("{\"toke\":\"toke\"}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary", mockDir, testFile, stdout)
+	getMeta("ary", mockDir, testFile, stdout, false)
 	expected = []byte("[\"aaa\",\"bbb\",{\"ccc\":{\"ddd\":[1234567,2,3]}}]")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary[0]", mockDir, testFile, stdout)
+	getMeta("ary[0]", mockDir, testFile, stdout, false)
 	expected = []byte("aaa")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary[2]", mockDir, testFile, stdout)
+	getMeta("ary[2]", mockDir, testFile, stdout, false)
 	expected = []byte("{\"ccc\":{\"ddd\":[1234567,2,3]}}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary[2].ccc", mockDir, testFile, stdout)
+	getMeta("ary[2].ccc", mockDir, testFile, stdout, false)
 	expected = []byte("{\"ddd\":[1234567,2,3]}")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary[2].ccc.ddd", mockDir, testFile, stdout)
+	getMeta("ary[2].ccc.ddd", mockDir, testFile, stdout, false)
 	expected = []byte("[1234567,2,3]")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("ary[2].ccc.ddd[1]", mockDir, testFile, stdout)
+	getMeta("ary[2].ccc.ddd[1]", mockDir, testFile, stdout, false)
 	expected = []byte("2")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
 	}
 
 	stdout = new(bytes.Buffer)
-	getMeta("nu", mockDir, testFile, stdout)
+	getMeta("nu", mockDir, testFile, stdout, false)
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
@@ -184,7 +186,7 @@ func TestGetMeta(t *testing.T) {
 
 	// The key does not exist in meta.json
 	stdout = new(bytes.Buffer)
-	getMeta("notexist", mockDir, testFile, stdout)
+	getMeta("notexist", mockDir, testFile, stdout, false)
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
@@ -192,7 +194,7 @@ func TestGetMeta(t *testing.T) {
 
 	// It makes golang zero-value
 	stdout = new(bytes.Buffer)
-	getMeta("ary[]", mockDir, testFile, stdout)
+	getMeta("ary[]", mockDir, testFile, stdout, false)
 	expected = []byte("aaa")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
@@ -200,10 +202,36 @@ func TestGetMeta(t *testing.T) {
 
 	// The key does not exist in meta.json
 	stdout = new(bytes.Buffer)
-	getMeta("ary.aaa.bbb.ccc.ddd[10]", mockDir, testFile, stdout)
+	getMeta("ary.aaa.bbb.ccc.ddd[10]", mockDir, testFile, stdout, false)
 	expected = []byte("null")
 	if bytes.Compare(expected, stdout.Bytes()) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(stdout.Bytes()))
+	}
+}
+
+func TestGetMeta_json_object(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "str",
+			key:      "str",
+			expected: `"fuga"`,
+		},
+		{
+			name:     "foo",
+			key:      "foo",
+			expected: `{"bar-baz":"dashed-key"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			err := getMeta(tc.key, mockDir, testFile, stdout, true)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, stdout.String())
+		})
 	}
 }
 
@@ -211,7 +239,7 @@ func TestSetMeta_bool(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("bool", "true", testDir, testFile)
+	setMeta("bool", "true", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -226,8 +254,8 @@ func TestSetMeta_number(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("int", "10", testDir, testFile)
-	setMeta("float", "15.5", testDir, testFile)
+	setMeta("int", "10", testDir, testFile, false)
+	setMeta("float", "15.5", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -242,7 +270,7 @@ func TestSetMeta_string(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("str", "val", testDir, testFile)
+	setMeta("str", "val", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -257,7 +285,7 @@ func TestSetMeta_flexibleKey(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("foo-bar", "val", testDir, testFile)
+	setMeta("foo-bar", "val", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -272,7 +300,7 @@ func TestSetMeta_array(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("array[]", "arg", testDir, testFile)
+	setMeta("array[]", "arg", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -287,7 +315,7 @@ func TestSetMeta_array_with_index(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("array[1]", "arg", testDir, testFile)
+	setMeta("array[1]", "arg", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -297,7 +325,7 @@ func TestSetMeta_array_with_index(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("array[2]", "argarg", testDir, testFile)
+	setMeta("array[2]", "argarg", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -312,8 +340,8 @@ func TestSetMeta_array_with_index_to_string(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("array[1]", "arg", testDir, testFile)
-	setMeta("array", "str", testDir, testFile)
+	setMeta("array[1]", "arg", testDir, testFile, false)
+	setMeta("array", "str", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -328,7 +356,7 @@ func TestSetMeta_object(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("foo.bar", "baz", testDir, testFile)
+	setMeta("foo.bar", "baz", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -338,7 +366,7 @@ func TestSetMeta_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.barbar", "bazbaz", testDir, testFile)
+	setMeta("foo.barbar", "bazbaz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -348,7 +376,7 @@ func TestSetMeta_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.bar.baz", "piyo", testDir, testFile)
+	setMeta("foo.bar.baz", "piyo", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -358,7 +386,7 @@ func TestSetMeta_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.bar-baz", "dashed-key", testDir, testFile)
+	setMeta("foo.bar-baz", "dashed-key", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -373,8 +401,8 @@ func TestSetMeta_object_to_string(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("foo.bar", "baz", testDir, testFile)
-	setMeta("foo", "baz", testDir, testFile)
+	setMeta("foo.bar", "baz", testDir, testFile, false)
+	setMeta("foo", "baz", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -389,7 +417,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("foo[1].bar", "baz", testDir, testFile)
+	setMeta("foo[1].bar", "baz", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -399,7 +427,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.bar[1]", "baz", testDir, testFile)
+	setMeta("foo.bar[1]", "baz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -409,7 +437,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[1].bar[1]", "baz", testDir, testFile)
+	setMeta("foo[1].bar[1]", "baz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -419,7 +447,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[0].bar[1]", "baz", testDir, testFile)
+	setMeta("foo[0].bar[1]", "baz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -429,7 +457,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[1].bar[0]", "ba", testDir, testFile)
+	setMeta("foo[1].bar[0]", "ba", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -439,7 +467,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[1].bar[2]", "bazbaz", testDir, testFile)
+	setMeta("foo[1].bar[2]", "bazbaz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -449,7 +477,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[1].bar[3].baz[1]", "qux", testDir, testFile)
+	setMeta("foo[1].bar[3].baz[1]", "qux", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -459,7 +487,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[1].bar[3].baz[0]", "quxqux", testDir, testFile)
+	setMeta("foo[1].bar[3].baz[0]", "quxqux", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -469,7 +497,7 @@ func TestSetMeta_array_with_object(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo[0].bar[3].baz[1]", "qux", testDir, testFile)
+	setMeta("foo[0].bar[3].baz[1]", "qux", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -484,7 +512,7 @@ func TestSetMeta_object_with_array(t *testing.T) {
 	setupDir(testDir, testFile)
 	os.Remove(testFilePath)
 
-	setMeta("foo.bar[1]", "baz", testDir, testFile)
+	setMeta("foo.bar[1]", "baz", testDir, testFile, false)
 	out, err := ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -494,7 +522,7 @@ func TestSetMeta_object_with_array(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.bar[0]", "baz0", testDir, testFile)
+	setMeta("foo.bar[0]", "baz0", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -504,7 +532,7 @@ func TestSetMeta_object_with_array(t *testing.T) {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
 	}
 
-	setMeta("foo.barbar[2]", "bazbaz", testDir, testFile)
+	setMeta("foo.barbar[2]", "bazbaz", testDir, testFile, false)
 	out, err = ioutil.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Meta file did not create. error: %v", err)
@@ -512,6 +540,38 @@ func TestSetMeta_object_with_array(t *testing.T) {
 	expected = []byte("{\"foo\":{\"bar\":[\"baz0\",\"baz\"],\"barbar\":[null,null,\"bazbaz\"]}}")
 	if bytes.Compare(expected, out) != 0 {
 		t.Fatalf("not matched. expected '%v', actual '%v'", string(expected), string(out))
+	}
+}
+
+func TestSetMeta_json_object(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		key      string
+		value    string
+		expected string
+	}{
+		{
+			name:     `{"foo":"bar"}`,
+			key:      "key",
+			value:    `{"foo":"bar"}`,
+			expected: `{"key":{"foo":"bar"}}`,
+		},
+		{
+			name:     `"foo"`,
+			key:      "key",
+			value:    `"foo"`,
+			expected: `{"key":"foo"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupDir(testDir, testFile)
+			os.Remove(testFilePath)
+
+			require.NoError(t, setMeta(tc.key, tc.value, testDir, testFile, true))
+			out, err := ioutil.ReadFile(testFilePath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(out))
+		})
 	}
 }
 


### PR DESCRIPTION
## Context

There are times when it's desirable to do a deep copy of metadata - for instance, when a scheduled job wants to get the lastSuccessfulMeta of a component job and copy it in so that jobs triggered off it have meta associated with the event (and can be re-run without taking another snapshot).

## Objective

Adds a flag -j or --json-value for get and set that treats the input string as a json-formatted string.

## References


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
