### PR TITLE
Add tests for symmetry with set/get using -j flag; also add test of error as requested in #20

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -549,6 +549,7 @@ func TestSetMeta_json_object(t *testing.T) {
 		key      string
 		value    string
 		expected string
+		wantErr  bool
 	}{
 		{
 			name:     `{"foo":"bar"}`,
@@ -562,10 +563,21 @@ func TestSetMeta_json_object(t *testing.T) {
 			value:    `"foo"`,
 			expected: `{"key":"foo"}`,
 		},
+		{
+			name:    `want error with bogus json`,
+			key:     "key",
+			value:   `"mismatched": "json"}`,
+			wantErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			setupDir(testDir, testFile)
-			os.Remove(testFilePath)
+			defer func() {
+				r := recover()
+				assert.Equal(t, tc.wantErr, r != nil, "wantErr %v; err %v", tc.wantErr, r)
+			}()
+
+			require.NoError(t, setupDir(testDir, testFile))
+			require.NoError(t, os.Remove(testFilePath))
 
 			require.NoError(t, setMeta(tc.key, tc.value, testDir, testFile, true))
 			out, err := ioutil.ReadFile(testFilePath)

--- a/meta_test.go
+++ b/meta_test.go
@@ -552,13 +552,19 @@ func TestSetMeta_json_object(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     `{"foo":"bar"}`,
+			name:     `json object`,
 			key:      "key",
 			value:    `{"foo":"bar"}`,
 			expected: `{"key":{"foo":"bar"}}`,
 		},
 		{
-			name:     `"foo"`,
+			name:     `json array`,
+			key:      "key",
+			value:    `[1, 2, 3]`,
+			expected: `{"key":[1,2,3]}`,
+		},
+		{
+			name:     `json string (quoted)`,
 			key:      "key",
 			value:    `"foo"`,
 			expected: `{"key":"foo"}`,
@@ -812,5 +818,59 @@ func TestMetaIndexFromKey(t *testing.T) {
 
 	if i != expected {
 		t.Fatalf("Expected '%d' but '%d'", expected, i)
+	}
+}
+
+func TestSymmetry_json_object(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		key                    string
+		expectJsonEqualNonJson bool
+	}{
+		{
+			name:                   `string value`,
+			key:                    "str",
+			expectJsonEqualNonJson: false,
+		},
+		{
+			name:                   `object value`,
+			key:                    "foo",
+			expectJsonEqualNonJson: true,
+		},
+		{
+			name:                   `array value`,
+			key:                    "ary",
+			expectJsonEqualNonJson: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Get the non-json value from mock
+			stdout := new(bytes.Buffer)
+			require.NoError(t, getMeta(tc.key, mockDir, testFile, stdout, false))
+			nonJsonValue := stdout.String()
+
+			// Get the json value from mock
+			stdout = new(bytes.Buffer)
+			require.NoError(t, getMeta(tc.key, mockDir, testFile, stdout, true))
+			jsonValue := stdout.String()
+
+			// Compare starting condition
+			if tc.expectJsonEqualNonJson {
+				assert.Equal(t, jsonValue, nonJsonValue)
+			} else {
+				assert.NotEqual(t, jsonValue, nonJsonValue)
+			}
+
+			// Reset the output for writing
+			require.NoError(t, setupDir(testDir, testFile))
+			require.NoError(t, os.Remove(testFilePath))
+
+			// Set and get the jsonValue to/from writable file with jsonValue true
+			require.NoError(t, setMeta(tc.key, jsonValue, testDir, testFile, true))
+			stdout = new(bytes.Buffer)
+			require.NoError(t, getMeta(tc.key, testDir, testFile, stdout, true))
+			newJsonValue := stdout.String()
+			assert.Equal(t, jsonValue, newJsonValue)
+		})
 	}
 }


### PR DESCRIPTION
## Context

A comment was made to #20 asking for a test of the error case; in addition, the intention of the `--json-value` flag as applied in the get command is to remain "symmetric" (`meta get -j foo` should be the same before and after `meta set -j foo "$(meta get -j foo)"`; so write a test to ensure that intention.

## Objective

No fixes; only tests

## References

#20 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
