### PR TITLE
commands should NOT repeat the "global" app flags otherwise flags in the global position are overwritten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,32 @@ COMMANDS:
 GLOBAL OPTIONS:
    --meta-space value          Location of meta temporarily (default: "/sd/meta")
    --external value, -e value  External pipeline meta (default: "meta")
-   --json-value, -j            Treat value as json
    --help, -h                  show help
    --version, -v               print the version
 
 COPYRIGHT:
    (c) 2017 Yahoo Inc.
+
+---
+NAME:
+   meta get - Get a metadata with key
+
+USAGE:
+   meta get [command options] [arguments...]
+
+OPTIONS:
+   --json-value, -j  Treat value as json
+
+---
+NAME:
+   meta set - Set a metadata with key and value
+
+USAGE:
+   meta set [command options] [arguments...]
+
+OPTIONS:
+   --json-value, -j  Treat value as json
+
 $ ./meta set aaa bbb
 $ ./meta get aaa
 bbb

--- a/meta.go
+++ b/meta.go
@@ -387,11 +387,11 @@ func main() {
 			Value:       "meta",
 			Destination: &metaFile,
 		},
-		cli.BoolFlag{
-			Name:        "json-value, j",
-			Usage:       "Treat value as json",
-			Destination: &jsonValue,
-		},
+	}
+	jsonValueFlag := cli.BoolFlag{
+		Name:        "json-value, j",
+		Usage:       "Treat value as json",
+		Destination: &jsonValue,
 	}
 
 	app.Commands = []cli.Command{
@@ -413,6 +413,7 @@ func main() {
 				successExit()
 				return nil
 			},
+			Flags: []cli.Flag{jsonValueFlag},
 		},
 		{
 			Name:  "set",
@@ -433,6 +434,7 @@ func main() {
 				successExit()
 				return nil
 			},
+			Flags: []cli.Flag{jsonValueFlag},
 		},
 	}
 

--- a/meta.go
+++ b/meta.go
@@ -413,7 +413,6 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: app.Flags,
 		},
 		{
 			Name:  "set",
@@ -434,9 +433,11 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: app.Flags,
 		},
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		failureExit(err)
+	}
 }


### PR DESCRIPTION
Competes with #26 as a way to remove the misuse of flags; choose only one and close the other.

## Context

the CLI library used has the notion of global and per-command flags.  The code currently puts the flags in both positions.  This means that clients _could_ use either syntax, but only one works properly.  Let the truly global flags remain global and remove from the sub-commands.

Currently, this works:
```meta get --external component foo```
But this does not.
```meta --external component get foo```

Both are allowed though only one works. Removing the ambiguity.

## Objective

1. Use the cli library properly
1. Remove ways of passing flags that are _allowed_ but _don't work properly_.

## References

<https://github.com/urfave/cli/blob/master/README.md>

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
