### PR TITLE
Ensure global options and command options are not duplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --help, -h                  show help
-   --version, -v               print the version
+   --meta-space value  Location of meta temporarily (default: "/sd/meta")
+   --help, -h          show help
+   --version, -v       print the version
 
 COPYRIGHT:
    (c) 2017 Yahoo Inc.
@@ -41,7 +42,6 @@ USAGE:
    meta get [command options] [arguments...]
 
 OPTIONS:
-   --meta-space value          Location of meta temporarily (default: "/sd/meta")
    --external value, -e value  External pipeline meta (default: "meta")
    --json-value, -j            Treat value as json
 
@@ -53,8 +53,7 @@ USAGE:
    meta set [command options] [arguments...]
 
 OPTIONS:
-   --meta-space value          Location of meta temporarily (default: "/sd/meta")
-   --json-value, -j            Treat value as json
+   --json-value, -j  Treat value as json
 
 $ ./meta set aaa bbb
 $ ./meta get aaa

--- a/README.md
+++ b/README.md
@@ -27,14 +27,36 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --meta-space value          Location of meta temporarily (default: "/sd/meta")
-   --external value, -e value  External pipeline meta (default: "meta")
-   --json-value, -j            Treat value as json
    --help, -h                  show help
    --version, -v               print the version
 
 COPYRIGHT:
    (c) 2017 Yahoo Inc.
+
+---
+NAME:
+   meta get - Get a metadata with key
+
+USAGE:
+   meta get [command options] [arguments...]
+
+OPTIONS:
+   --meta-space value          Location of meta temporarily (default: "/sd/meta")
+   --external value, -e value  External pipeline meta (default: "meta")
+   --json-value, -j            Treat value as json
+
+---
+NAME:
+   meta set - Set a metadata with key and value
+
+USAGE:
+   meta set [command options] [arguments...]
+
+OPTIONS:
+   --meta-space value          Location of meta temporarily (default: "/sd/meta")
+   --external value, -e value  External pipeline meta (default: "meta")
+   --json-value, -j            Treat value as json
+
 $ ./meta set aaa bbb
 $ ./meta get aaa
 bbb

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ USAGE:
 
 OPTIONS:
    --meta-space value          Location of meta temporarily (default: "/sd/meta")
-   --external value, -e value  External pipeline meta (default: "meta")
    --json-value, -j            Treat value as json
 
 $ ./meta set aaa bbb

--- a/meta.go
+++ b/meta.go
@@ -374,19 +374,17 @@ func main() {
 	}
 	app.Copyright = "(c) 2017-" + date + " Yahoo Inc."
 
-	commonFlags := []cli.Flag{
-		cli.StringFlag{
-			Name:        "meta-space",
-			Usage:       "Location of meta temporarily",
-			Value:       "/sd/meta",
-			Destination: &metaSpace,
-		},
-		cli.StringFlag{
-			Name:        "external, e",
-			Usage:       "External pipeline meta",
-			Value:       "meta",
-			Destination: &metaFile,
-		},
+	metaSpaceFlag := cli.StringFlag{
+		Name:        "meta-space",
+		Usage:       "Location of meta temporarily",
+		Value:       "/sd/meta",
+		Destination: &metaSpace,
+	}
+	externalFlag := cli.StringFlag{
+		Name:        "external, e",
+		Usage:       "External pipeline meta",
+		Value:       "meta",
+		Destination: &metaFile,
 	}
 	jsonValueFlag := cli.BoolFlag{
 		Name:        "json-value, j",
@@ -413,7 +411,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: append(commonFlags, jsonValueFlag),
+			Flags: []cli.Flag{metaSpaceFlag, externalFlag, jsonValueFlag},
 		},
 		{
 			Name:  "set",
@@ -434,7 +432,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: append(commonFlags, jsonValueFlag),
+			Flags: []cli.Flag{metaSpaceFlag, jsonValueFlag},
 		},
 	}
 

--- a/meta.go
+++ b/meta.go
@@ -392,6 +392,8 @@ func main() {
 		Destination: &jsonValue,
 	}
 
+	app.Flags = []cli.Flag{metaSpaceFlag}
+
 	app.Commands = []cli.Command{
 		{
 			Name:  "get",
@@ -411,7 +413,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: []cli.Flag{metaSpaceFlag, externalFlag, jsonValueFlag},
+			Flags: []cli.Flag{externalFlag, jsonValueFlag},
 		},
 		{
 			Name:  "set",
@@ -432,7 +434,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: []cli.Flag{metaSpaceFlag, jsonValueFlag},
+			Flags: []cli.Flag{jsonValueFlag},
 		},
 	}
 

--- a/meta.go
+++ b/meta.go
@@ -374,7 +374,7 @@ func main() {
 	}
 	app.Copyright = "(c) 2017-" + date + " Yahoo Inc."
 
-	app.Flags = []cli.Flag{
+	commonFlags := []cli.Flag{
 		cli.StringFlag{
 			Name:        "meta-space",
 			Usage:       "Location of meta temporarily",
@@ -387,11 +387,11 @@ func main() {
 			Value:       "meta",
 			Destination: &metaFile,
 		},
-		cli.BoolFlag{
-			Name:        "json-value, j",
-			Usage:       "Treat value as json",
-			Destination: &jsonValue,
-		},
+	}
+	jsonValueFlag := cli.BoolFlag{
+		Name:        "json-value, j",
+		Usage:       "Treat value as json",
+		Destination: &jsonValue,
 	}
 
 	app.Commands = []cli.Command{
@@ -413,7 +413,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: app.Flags,
+			Flags: append(commonFlags, jsonValueFlag),
 		},
 		{
 			Name:  "set",
@@ -434,7 +434,7 @@ func main() {
 				successExit()
 				return nil
 			},
-			Flags: app.Flags,
+			Flags: append(commonFlags, jsonValueFlag),
 		},
 	}
 


### PR DESCRIPTION
If options _were_ passed in the global spot (before the command) then they were overwritten by the commands' flag parsing (default value).

Competes with #25 and I believe is superior as it is closer to backward-compatible with existing jobs. The only incompatibility will be for any jobs using the `--meta-space` flag, that will now need to put that before the command as the `urfave/cli` library seems to demand global options before commands (unlike spf13/cobra which allows mixing of flags)
```
meta get foo --meta-space "$PWD/meta" --external sd@123:other-job
```
would need to be
```
meta --meta-space "$PWD/meta" get foo --external sd@123:other-job
```

## Context

the CLI library used has the notion of global and per-command flags.  The code currently puts the flags in both positions.  This means that clients _could_ use either syntax, but only one works properly.  Let the truly global flags remain global and remove from the sub-commands.

Currently, this works:
```meta get --external component foo```
But this does not.
```meta --external component get foo```

Both are allowed though only one works. Removing the ambiguity.

## Objective

1. Use the cli library properly
1. Remove ways of passing flags that are _allowed_ but _don't work properly_.

## References

<https://github.com/urfave/cli/blob/master/README.md>

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
