### PR TITLE
Set the default of metaFile to "meta".

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -358,9 +358,10 @@ func finalRecover() {
 func main() {
 	defer finalRecover()
 
-	var metaSpace string
-	var metaFile string
-	var jsonValue bool
+	// Set to defaults in case not all commands alter these variables with flags.
+	var metaSpace string = "/sd/meta"
+	var metaFile string = "meta"
+	var jsonValue bool = false
 
 	app := cli.NewApp()
 	app.Name = "meta-cli"


### PR DESCRIPTION
## Context

#26 reduced the number of global flags; variables now need default settings for the case where they're not defaulted with the flags mechanism.  Specifically, `meta set foo bar` fails with `ERROR: can only meta set current build meta` currently.

## Objective

`ERROR: can only meta set current build meta`

## References

#26 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
