### PR TITLE
Error when extra args are passed.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -532,7 +532,7 @@ func main() {
 			Name:  "get",
 			Usage: "Get a metadata with key",
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) != 1 {
+				if c.NArg() != 1 {
 					logrus.Error("meta get expects exactly one argument (key)")
 					return cli.ShowCommandHelp(c, "get")
 				}
@@ -559,7 +559,7 @@ func main() {
 			Name:  "set",
 			Usage: "Set a metadata with key and value",
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) != 2 {
+				if c.NArg() != 2 {
 					logrus.Error("meta set expects exactly two arguments (key, value)")
 					return cli.ShowCommandHelp(c, "set")
 				}

--- a/meta.go
+++ b/meta.go
@@ -560,7 +560,7 @@ func main() {
 			Usage: "Set a metadata with key and value",
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
-					logrus.Error("meta get expects exactly two arguments (key, value)")
+					logrus.Error("meta set expects exactly two arguments (key, value)")
 					return cli.ShowCommandHelp(c, "set")
 				}
 				key := c.Args().Get(0)

--- a/meta.go
+++ b/meta.go
@@ -532,8 +532,9 @@ func main() {
 			Name:  "get",
 			Usage: "Get a metadata with key",
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) == 0 {
-					return cli.ShowAppHelp(c)
+				if len(c.Args()) != 1 {
+					logrus.Error("meta get expects exactly one argument (key)")
+					return cli.ShowCommandHelp(c, "get")
 				}
 				key := c.Args().Get(0)
 				if valid := validateMetaKey(key); !valid {
@@ -558,8 +559,9 @@ func main() {
 			Name:  "set",
 			Usage: "Set a metadata with key and value",
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) <= 1 {
-					return cli.ShowAppHelp(c)
+				if len(c.Args()) != 2 {
+					logrus.Error("meta get expects exactly two arguments (key, value)")
+					return cli.ShowCommandHelp(c, "set")
 				}
 				key := c.Args().Get(0)
 				val := c.Args().Get(1)


### PR DESCRIPTION
## Context

Recently someone asked why `meta get --external sd@12345:jobName --skip-fetch true theKey` didn't work - and it was because `true` was _not_ passed to `--skip-fetch`, which is a bool flag (absent is false, present is true) so true was passed as the first arg and the second arg (intended to be the key) was just ignored.

## Objective

Report errors when extraneous args are passed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
