### PR TITLE
JobName can have dashes in it

### DIFF
--- a/internal/fetch/jobDescription.go
+++ b/internal/fetch/jobDescription.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-var jobDescriptionSDRegExp = regexp.MustCompile(`^sd@(\d+):(\w+)$`)
+var jobDescriptionSDRegExp = regexp.MustCompile(`^sd@(\d+):([\w-]+)$`)
 
 type JobDescription struct {
 	// The base name of the meta file (without the .json extension)

--- a/internal/fetch/jobDescription_test.go
+++ b/internal/fetch/jobDescription_test.go
@@ -31,6 +31,15 @@ func (s *JobDescriptionSuite) Test_parseJobDescription() {
 			},
 		},
 		{
+			jobDescription:    `sd@123:myName-with-dashes`,
+			defaultPipelineID: 999,
+			want: &JobDescription{
+				MetaFile:   `sd@123:myName-with-dashes`,
+				PipelineID: 123,
+				JobName:    "myName-with-dashes",
+			},
+		},
+		{
 			jobDescription:    `myName`,
 			defaultPipelineID: 123,
 			want: &JobDescription{


### PR DESCRIPTION
## Context

JobName parsing fails because `-` throws the regular-expression off.

## Objective

Allow `--external` to have jobNames with dashes in them.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
