### PR TITLE
--skip-meta shouldn't cache in default meta.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -100,7 +100,7 @@ func (m *MetaSpec) GetExternalData() ([]byte, error) {
 			return []byte("{}"), nil
 		}
 		logrus.Debugf("%s doesn't exist; setting up", metaFilePath)
-		metaData, err = m.SetupDir()
+		_, err = m.SetupDir()
 		if err != nil {
 			return nil, err
 		}

--- a/meta.go
+++ b/meta.go
@@ -94,17 +94,19 @@ func (m *MetaSpec) GetExternalData() ([]byte, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
+		// If we shouldn't fetch, then return without caching in the default meta.
+		if m.SkipFetchNonexistentExternal {
+			logrus.Debugf("%s doesn't exist; skipping fetch", metaFilePath)
+			return []byte("{}"), nil
+		}
 		logrus.Debugf("%s doesn't exist; setting up", metaFilePath)
 		metaData, err = m.SetupDir()
 		if err != nil {
 			return nil, err
 		}
-		// Fetch if we should
-		if !m.SkipFetchNonexistentExternal {
-			logrus.Debugf("Fetching metadata from %s", jobDescription.External())
-			if metaData, err = m.LastSuccessfulMetaRequest.FetchLastSuccessfulMeta(jobDescription); err != nil {
-				return nil, err
-			}
+		logrus.Debugf("Fetching metadata from %s", jobDescription.External())
+		if metaData, err = m.LastSuccessfulMetaRequest.FetchLastSuccessfulMeta(jobDescription); err != nil {
+			return nil, err
 		}
 	}
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -793,6 +793,12 @@ func (s *MetaSuite) TestMetaSpec_GetExternalData() {
 			Require.NoError(err)
 			s.Assert().Equal(tt.expected, string(got))
 			mockHandler.AssertExpectations(s.T())
+
+			// Ensure that the caching behavior works too
+			s.Assert().FileExists(metaSpec.MetaFilePath())
+			defaultMeta := metaSpec.CloneDefaultMeta()
+			sdVal, err := defaultMeta.Get("sd")
+			s.Assert().NotEqual("null", sdVal, "sd should have cached values but was %s", sdVal)
 		})
 	}
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -798,6 +798,7 @@ func (s *MetaSuite) TestMetaSpec_GetExternalData() {
 			s.Assert().FileExists(metaSpec.MetaFilePath())
 			defaultMeta := metaSpec.CloneDefaultMeta()
 			sdVal, err := defaultMeta.Get("sd")
+			s.Assert().NoError(err)
 			s.Assert().NotEqual("null", sdVal, "sd should have cached values but was %s", sdVal)
 		})
 	}
@@ -819,6 +820,6 @@ func (s *MetaSuite) TestMetaSpec_SkipFetchDoesntSave() {
 
 	defaultMeta := metaSpec.CloneDefaultMeta()
 	sdVal, err := defaultMeta.Get("sd")
-	s.Require().NoError(err, `Should be able to get missing "sd" key without err`);
+	s.Require().NoError(err, `Should be able to get missing "sd" key without err`)
 	s.Assert().Equal("null", sdVal, "sd should not have any cached values, but had %s", sdVal)
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -796,3 +796,23 @@ func (s *MetaSuite) TestMetaSpec_GetExternalData() {
 		})
 	}
 }
+
+func (s *MetaSuite) TestMetaSpec_SkipFetchDoesntSave() {
+	metaSpec := MetaSpec{
+		MetaFile:                     "sd@1016708:job1",
+		MetaSpace:                    testDir,
+		SkipFetchNonexistentExternal: true,
+	}
+	got, err := metaSpec.GetExternalData()
+	s.Require().NoError(err)
+	s.Assert().Equal("{}", string(got))
+	_, err = os.Stat(metaSpec.MetaFilePath())
+	s.Assert().Error(err, "File not expected to exist %s", metaSpec.MetaFilePath())
+	s.Assert().True(os.IsNotExist(err),
+		"File not expected to exist %s; err %v", metaSpec.MetaFilePath(), err)
+
+	defaultMeta := metaSpec.CloneDefaultMeta()
+	sdVal, err := defaultMeta.Get("sd")
+	s.Require().NoError(err, `Should be able to get missing "sd" key without err`);
+	s.Assert().Equal("null", sdVal, "sd should not have any cached values, but had %s", sdVal)
+}


### PR DESCRIPTION
## Context

When `--skip-meta` flag is passed, empty external metadata (`{}`) should not be stored in default meta.

## Objective

```
# This should _NOT_ fetch
meta get foo --external sd@123:other --skip-fetch
# This should still fetch
meta get foo --external sd@123:other
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
