### PR TITLE
Check for passing flags to --external by looking for jobName starting with dash

### DIFF
--- a/internal/fetch/jobDescription.go
+++ b/internal/fetch/jobDescription.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 var jobDescriptionSDRegExp = regexp.MustCompile(`^sd@(\d+):([\w-]+)$`)
@@ -19,6 +20,9 @@ type JobDescription struct {
 
 // ParseJobDescription parses the string of the form sd@123:jobName or jobName to create a new JobDescription object
 func ParseJobDescription(defaultPipelineID int64, external string) (*JobDescription, error) {
+	if strings.HasPrefix(external, "-") {
+		return nil, fmt.Errorf(`--external "%s" appears to be a flag; not an external description`, external)
+	}
 	ret := &JobDescription{
 		MetaFile:   external,
 		PipelineID: defaultPipelineID,

--- a/internal/fetch/jobDescription_test.go
+++ b/internal/fetch/jobDescription_test.go
@@ -48,6 +48,11 @@ func (s *JobDescriptionSuite) Test_parseJobDescription() {
 				JobName:    "myName",
 			},
 		},
+		{
+			jobDescription:    `--skip-fetch`,
+			defaultPipelineID: 123,
+			wantErr:           true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/meta.go
+++ b/meta.go
@@ -542,6 +542,9 @@ func main() {
 				if valid := validateMetaKey(key); !valid {
 					failureExit(errors.New("meta key validation error"))
 				}
+				if _, err := fetch.ParseJobDescription(metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineId, metaSpec.MetaFile); metaSpec.IsExternal() && err != nil {
+					failureExit(err)
+				}
 				value, err := metaSpec.Get(key)
 				if err != nil {
 					failureExit(err)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If users invoke like ```meta get --external --skip-fetch sd@123:main theKey``` it would be better to explain that `--skip-fetch` was being passed to `--external` to help self-diagnose.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
