### PR TITLE
Make meta concurrency-safe using flock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/screwdriver-cd/meta-cli
 go 1.12
 
 require (
+	github.com/gofrs/flock v0.7.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/screwdriver-cd/meta-cli
 go 1.12
 
 require (
-	github.com/gofrs/flock v0.7.1 // indirect
+	github.com/gofrs/flock v0.7.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/fetch/jobDescription.go
+++ b/internal/fetch/jobDescription.go
@@ -9,6 +9,7 @@ import (
 
 var jobDescriptionSDRegExp = regexp.MustCompile(`^sd@(\d+):([\w-]+)$`)
 
+// JobDescription describes a screwdriver job.
 type JobDescription struct {
 	// The base name of the meta file (without the .json extension)
 	MetaFile string

--- a/internal/fetch/lastSuccessfulMeta.go
+++ b/internal/fetch/lastSuccessfulMeta.go
@@ -9,16 +9,17 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// LastSuccessfulMetaRequest describes a request for the SD lastSuccessfulMeta API call.
 type LastSuccessfulMetaRequest struct {
-	// The screwdriver OAuth2 token
+	// SdToken is the screwdriver OAuth2 token
 	SdToken string
-	// The base url to the screwdriver rest API.
-	SdApiUrl string
+	// SdAPIURL is the base url to the screwdriver rest API.
+	SdAPIURL string
 
-	// The default pipeline id to handle external names with just the jobName (no sd@pipelineId)
-	DefaultSdPipelineId int64
+	// DefaultSdPipelineID is the default pipeline id to handle external names with just the jobName (no sd@pipelineId)
+	DefaultSdPipelineID int64
 
-	// The transport to use in calling the screwdriver REST apis (when nil, uses http.DefaultTransport)
+	// Is the transport to use in calling the screwdriver REST apis (when nil, uses http.DefaultTransport)
 	Transport http.RoundTripper
 }
 
@@ -32,21 +33,21 @@ func (r *LastSuccessfulMetaRequest) GetTransport() http.RoundTripper {
 
 // LastSuccessfulMetaURL returns the URL for using the screwdriver lastSuccessfulMeta REST API
 func (r *LastSuccessfulMetaRequest) LastSuccessfulMetaURL(jobID int64) string {
-	return fmt.Sprintf("%sjobs/%d/lastSuccessfulMeta", r.SdApiUrl, jobID)
+	return fmt.Sprintf("%sjobs/%d/lastSuccessfulMeta", r.SdAPIURL, jobID)
 }
 
 // JobsForPipelineURL returns the URL for using the screwdriver jobs REST API for a given pipelineID
 func (r *LastSuccessfulMetaRequest) JobsForPipelineURL(piplineID int64) string {
-	return fmt.Sprintf("%spipelines/%d/jobs", r.SdApiUrl, piplineID)
+	return fmt.Sprintf("%spipelines/%d/jobs", r.SdAPIURL, piplineID)
 }
 
 // JobForPipelineURL returns the URL for using the screwdriver jobs REST API for a given pipelineID and jobName
 func (r *LastSuccessfulMetaRequest) JobForPipelineURL(piplineID int64, jobName string) string {
-	return fmt.Sprintf("%spipelines/%d/jobs?jobName=%s", r.SdApiUrl, piplineID, jobName)
+	return fmt.Sprintf("%spipelines/%d/jobs?jobName=%s", r.SdAPIURL, piplineID, jobName)
 }
 
-// JobIdFromJsonByName extracts the ID of the given jobName from the json string
-func (r *LastSuccessfulMetaRequest) JobIdFromJsonByName(json, jobName string) (int64, error) {
+// JobIDFromJSONByName extracts the ID of the given jobName from the json string
+func (r *LastSuccessfulMetaRequest) JobIDFromJSONByName(json, jobName string) (int64, error) {
 	result := gjson.Get(json, fmt.Sprintf("#(name==%#v).id", jobName))
 	if !result.Exists() {
 		return 0, fmt.Errorf("jobName %v not found in json", jobName)
@@ -54,11 +55,11 @@ func (r *LastSuccessfulMetaRequest) JobIdFromJsonByName(json, jobName string) (i
 	return result.Int(), nil
 }
 
-// FetchJobId fetches the job information from the given jobDescription, parses and returns the job id
-func (r *LastSuccessfulMetaRequest) FetchJobId(jobDescription *JobDescription) (int64, error) {
+// FetchJobID fetches the job information from the given jobDescription, parses and returns the job id
+func (r *LastSuccessfulMetaRequest) FetchJobID(jobDescription *JobDescription) (int64, error) {
 	if jobDescription.PipelineID == 0 {
-		logrus.Debugf("Defaulting pipelineId to %d", r.DefaultSdPipelineId)
-		jobDescription.PipelineID = r.DefaultSdPipelineId
+		logrus.Debugf("Defaulting pipelineId to %d", r.DefaultSdPipelineID)
+		jobDescription.PipelineID = r.DefaultSdPipelineID
 	}
 	if jobDescription.PipelineID == 0 {
 		return 0, fmt.Errorf("jobDescription does not have pipelineID %#v", jobDescription)
@@ -78,17 +79,17 @@ func (r *LastSuccessfulMetaRequest) FetchJobId(jobDescription *JobDescription) (
 	if err != nil {
 		return 0, err
 	}
-	return r.JobIdFromJsonByName(string(data), jobDescription.JobName)
+	return r.JobIDFromJSONByName(string(data), jobDescription.JobName)
 }
 
 // FetchLastSuccessfulMeta fetches the last successful meta from the given jobDescription and returns raw data
 func (r *LastSuccessfulMetaRequest) FetchLastSuccessfulMeta(jobDescription *JobDescription) ([]byte, error) {
-	jobId, err := r.FetchJobId(jobDescription)
+	jobID, err := r.FetchJobID(jobDescription)
 	if err != nil {
 		return nil, err
 	}
-	logrus.Tracef("jobId=%d", jobId)
-	lastSuccessfulMetaURL := r.LastSuccessfulMetaURL(jobId)
+	logrus.Tracef("jobID=%d", jobID)
+	lastSuccessfulMetaURL := r.LastSuccessfulMetaURL(jobID)
 	logrus.Tracef("lastSuccessfulMetaURL=%s", lastSuccessfulMetaURL)
 	request, err := http.NewRequest("GET", lastSuccessfulMetaURL, nil)
 	if err != nil {

--- a/internal/fetch/lastSuccessfulMeta_test.go
+++ b/internal/fetch/lastSuccessfulMeta_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	mockHttpDir            = "../../mockHttp"
-	jobsJsonFile           = "jobs.json"
+	mockHTTPDir            = "../../mockHttp"
+	jobsJSONFile           = "jobs.json"
 	lastSuccessfulMetaFile = "lastSuccessfulMeta.json"
 )
 
@@ -28,18 +28,18 @@ func (m *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type LastSuccessfulMetaSuite struct {
 	suite.Suite
-	JobsJson               string
-	LastSuccessfulMetaJson string
+	JobsJSON               string
+	LastSuccessfulMetaJSON string
 }
 
 func (s *LastSuccessfulMetaSuite) SetupSuite() {
-	data, err := ioutil.ReadFile(filepath.Join(mockHttpDir, jobsJsonFile))
+	data, err := ioutil.ReadFile(filepath.Join(mockHTTPDir, jobsJSONFile))
 	s.Require().NoError(err)
-	s.JobsJson = string(data)
+	s.JobsJSON = string(data)
 
-	data, err = ioutil.ReadFile(filepath.Join(mockHttpDir, lastSuccessfulMetaFile))
+	data, err = ioutil.ReadFile(filepath.Join(mockHTTPDir, lastSuccessfulMetaFile))
 	s.Require().NoError(err)
-	s.LastSuccessfulMetaJson = string(data)
+	s.LastSuccessfulMetaJSON = string(data)
 }
 
 func TestLastSuccessfulMetaSuite(t *testing.T) {
@@ -55,7 +55,7 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_LastSuccessfulMe
 	}{
 		{
 			request: LastSuccessfulMetaRequest{
-				SdApiUrl: "https://api.screwdriver.ouroath.com/v4/",
+				SdAPIURL: "https://api.screwdriver.ouroath.com/v4/",
 			},
 			jobID:    123,
 			expected: "https://api.screwdriver.ouroath.com/v4/jobs/123/lastSuccessfulMeta",
@@ -97,7 +97,7 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_JobIdFromJsonByN
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			got, err := tt.request.JobIdFromJsonByName(s.JobsJson, tt.jobName)
+			got, err := tt.request.JobIDFromJSONByName(s.JobsJSON, tt.jobName)
 			if tt.wantErr {
 				s.Require().Error(err)
 				return
@@ -151,15 +151,15 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_GetOrFetchJobId(
 			})).
 				Once().
 				Run(func(args mock.Arguments) {
-					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.JobsJson)
+					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.JobsJSON)
 				})
 			testServer := httptest.NewServer(&mockHandler)
 			defer testServer.Close()
 
-			tt.request.SdApiUrl = testServer.URL + "/v4/"
+			tt.request.SdAPIURL = testServer.URL + "/v4/"
 			tt.request.SdToken = "test-token"
 			tt.request.Transport = testServer.Client().Transport
-			got, err := tt.request.FetchJobId(&tt.jobDescription)
+			got, err := tt.request.FetchJobID(&tt.jobDescription)
 			if tt.wantErr {
 				s.Require().Error(err)
 				return
@@ -185,7 +185,7 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_GetLastSuccessfu
 				PipelineID: 1016708,
 				JobName:    "job1",
 			},
-			expected: s.LastSuccessfulMetaJson,
+			expected: s.LastSuccessfulMetaJSON,
 		},
 	}
 
@@ -198,7 +198,7 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_GetLastSuccessfu
 			})).
 				Once().
 				Run(func(args mock.Arguments) {
-					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.JobsJson)
+					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.JobsJSON)
 				})
 			mockHandler.On("ServeHTTP", mock.Anything, mock.MatchedBy(func(req *http.Request) bool {
 				return req.URL.Path == "/v4/jobs/392525/lastSuccessfulMeta" &&
@@ -206,12 +206,12 @@ func (s *LastSuccessfulMetaSuite) TestLastSuccessfulMetaRequest_GetLastSuccessfu
 			})).
 				Once().
 				Run(func(args mock.Arguments) {
-					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.LastSuccessfulMetaJson)
+					_, _ = io.WriteString(args.Get(0).(http.ResponseWriter), s.LastSuccessfulMetaJSON)
 				})
 			testServer := httptest.NewServer(&mockHandler)
 			defer testServer.Close()
 
-			tt.request.SdApiUrl = testServer.URL + "/v4/"
+			tt.request.SdAPIURL = testServer.URL + "/v4/"
 			tt.request.SdToken = "test-token"
 			tt.request.Transport = testServer.Client().Transport
 			got, err := tt.request.FetchLastSuccessfulMeta(&tt.jobDescription)

--- a/meta.go
+++ b/meta.go
@@ -73,7 +73,7 @@ func (m *MetaSpec) CloneDefaultMeta() *MetaSpec {
 // GetExternalData gets external data from meta key, external file, or fetching from lastSuccessfulMeta
 func (m *MetaSpec) GetExternalData() ([]byte, error) {
 	// Get the job description of the external job for looking up or fetching
-	jobDescription, err := fetch.ParseJobDescription(m.LastSuccessfulMetaRequest.DefaultSdPipelineId, m.MetaFile)
+	jobDescription, err := fetch.ParseJobDescription(m.LastSuccessfulMetaRequest.DefaultSdPipelineID, m.MetaFile)
 	if err != nil {
 		return nil, err
 	}
@@ -506,13 +506,13 @@ func main() {
 		Usage:       "Set the SD_API_URL to use in SD API calls",
 		EnvVar:      "SD_API_URL",
 		Value:       "https://api.screwdriver.cd/v4/",
-		Destination: &metaSpec.LastSuccessfulMetaRequest.SdApiUrl,
+		Destination: &metaSpec.LastSuccessfulMetaRequest.SdAPIURL,
 	}
 	sdPipelineIDFlag := cli.Int64Flag{
 		Name:        "sd-pipeline-id, p",
 		Usage:       "Set the SD_PIPELINE_ID of the job for fetching last successful meta",
 		EnvVar:      "SD_PIPELINE_ID",
-		Destination: &metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineId,
+		Destination: &metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineID,
 	}
 	sdLoglevelFlag := cli.StringFlag{
 		Name:        "loglevel, l",
@@ -556,7 +556,7 @@ func main() {
 				if valid := validateMetaKey(key); !valid {
 					failureExit(errors.New("meta key validation error"))
 				}
-				if _, err := fetch.ParseJobDescription(metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineId, metaSpec.MetaFile); metaSpec.IsExternal() && err != nil {
+				if _, err := fetch.ParseJobDescription(metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineID, metaSpec.MetaFile); metaSpec.IsExternal() && err != nil {
 					failureExit(err)
 				}
 				value, err := metaSpec.Get(key)

--- a/meta.go
+++ b/meta.go
@@ -542,8 +542,9 @@ func main() {
 			Name:  "get",
 			Usage: "Get a metadata with key",
 			Action: func(c *cli.Context) error {
+				// Ensure that the CLI is concurrency safe. Get may write if fetching lastSuccessful; lock exclusively.
 				flocker := flock.New(lockfile)
-				if err := flocker.RLock(); err != nil {
+				if err := flocker.Lock(); err != nil {
 					failureExit(err)
 				}
 				defer func() { _ = flocker.Unlock() }()
@@ -578,6 +579,7 @@ func main() {
 			Name:  "set",
 			Usage: "Set a metadata with key and value",
 			Action: func(c *cli.Context) error {
+				// Ensure that the CLI is concurrency safe.
 				flocker := flock.New(lockfile)
 				if err := flocker.Lock(); err != nil {
 					failureExit(err)

--- a/meta_test.go
+++ b/meta_test.go
@@ -780,7 +780,7 @@ func (s *MetaSuite) TestMetaSpec_GetExternalData() {
 				MetaFile:  tt.external,
 				MetaSpace: tempDir,
 				LastSuccessfulMetaRequest: fetch.LastSuccessfulMetaRequest{
-					SdApiUrl:  testServer.URL + "/v4/",
+					SdAPIURL:  testServer.URL + "/v4/",
 					Transport: testServer.Client().Transport,
 				},
 			}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
if meta set is invoked multiple times in parallel, corruption of the underlying json file(s) can occur.

## Objective

Using flock, ensure that both get and set obtain an exclusive (aka "write") lock (we could make it more granular, but get does the fetching logic now, so might do writes).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/gofrs/flock

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
