### PR TITLE
Do not write the external file if it didn't exist.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -102,12 +102,8 @@ func (m *MetaSpec) GetExternalData() ([]byte, error) {
 			logrus.Debugf("%s doesn't exist; skipping fetch", metaFilePath)
 			return []byte("{}"), nil
 		}
-		logrus.Debugf("%s doesn't exist; setting up", metaFilePath)
-		_, err = m.SetupDir()
-		if err != nil {
-			return nil, err
-		}
-		logrus.Debugf("Fetching metadata from %s", jobDescription.External())
+		logrus.Debugf("%s doesn't exist; setting up fetching metadata from %s",
+			metaFilePath, jobDescription.External())
 		if metaData, err = m.LastSuccessfulMetaRequest.FetchLastSuccessfulMeta(jobDescription); err != nil {
 			return nil, err
 		}

--- a/meta.go
+++ b/meta.go
@@ -102,8 +102,7 @@ func (m *MetaSpec) GetExternalData() ([]byte, error) {
 			logrus.Debugf("%s doesn't exist; skipping fetch", metaFilePath)
 			return []byte("{}"), nil
 		}
-		logrus.Debugf("%s doesn't exist; setting up fetching metadata from %s",
-			metaFilePath, jobDescription.External())
+		logrus.Debugf("%s doesn't exist; fetching metadata from %s", metaFilePath, jobDescription.External())
 		if metaData, err = m.LastSuccessfulMetaRequest.FetchLastSuccessfulMeta(jobDescription); err != nil {
 			return nil, err
 		}

--- a/meta_test.go
+++ b/meta_test.go
@@ -834,7 +834,8 @@ func (s *MetaSuite) TestMetaSpec_GetExternalData() {
 			mockHandler.AssertExpectations(s.T())
 
 			// Ensure that the caching behavior works too
-			s.Assert().FileExists(metaSpec.MetaFilePath())
+			_, err = os.Stat(metaSpec.MetaFilePath())
+			s.Assert().True(os.IsNotExist(err), "%s should not exist", metaSpec.MetaFilePath())
 			defaultMeta := metaSpec.CloneDefaultMeta()
 			sdVal, err := defaultMeta.Get("sd")
 			s.Assert().NoError(err)

--- a/meta_test.go
+++ b/meta_test.go
@@ -112,6 +112,18 @@ func (s *MetaSuite) TestExternalMetaFileDeletesSd() {
 	s.Assert().Equal("null", got)
 }
 
+func (s *MetaSuite) TestExternalMetaDoesntCreateFile() {
+	s.MetaSpec.MetaFile = externalFile2
+	s.MetaSpec.SkipFetchNonexistentExternal = true
+
+	// Test set (meta file is not meta.json, should fail)
+	got, err := s.MetaSpec.Get("sd")
+	s.Require().NoError(err)
+	s.Assert().Equal("null", got)
+	_, err = os.Stat(externalFile2Path)
+	s.Assert().True(os.IsNotExist(err), "%s should not exist", externalFile2Path)
+}
+
 func (s *MetaSuite) TestGetMetaNoFile() {
 	_ = os.RemoveAll(testDir)
 	got, err := s.MetaSpec.Get("woof")


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
It can be confusing to see an external meta file with `{}` in it but a meta.json with the fully fetched external metadata.  Taking the stance of leaving the external file readonly, don't create an empty json object when the file doesn't exist.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
