### PR TITLE
Add --cache-local flag to fetch external keys to remote meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ OPTIONS:
    --sd-api-url value, -u value      Set the SD_API_URL to use in SD API calls (default: "https://api.screwdriver.cd/v4/") [$SD_API_URL]
    --sd-pipeline-id value, -p value  Set the SD_PIPELINE_ID of the job for fetching last successful meta (default: 0) [$SD_PIPELINE_ID]
    --skip-store                      Used with --external to skip storing external metadata in the local meta
+   --cache-local                     Used with external, this flag saves a copy of the key/value pair in the local meta
 
 ---
 NAME:

--- a/meta_test.go
+++ b/meta_test.go
@@ -835,3 +835,79 @@ func (s *MetaSuite) TestMetaSpec_SkipFetchDoesntSave() {
 	s.Require().NoError(err, `Should be able to get missing "sd" key without err`)
 	s.Assert().Equal("null", sdVal, "sd should not have any cached values, but had %s", sdVal)
 }
+
+func (s *MetaSuite) TestMetaSpec_CachedGet() {
+	tests := []struct {
+		name     string
+		spec     MetaSpec
+		key      string
+		want     string
+		validate func(spec *MetaSpec, got string)
+		wantErr  bool
+	}{
+		{
+			name: "str",
+			spec: MetaSpec{
+				MetaSpace:  testDir,
+				MetaFile:   externalFile,
+				JSONValue:  false,
+				CacheLocal: true,
+			},
+			key:  "str",
+			want: "meow",
+		},
+		{
+			name: "obj.abc",
+			spec: MetaSpec{
+				MetaSpace:  testDir,
+				MetaFile:   externalFile,
+				JSONValue:  false,
+				CacheLocal: true,
+			},
+			key:  "obj.abc",
+			want: "def",
+		},
+		{
+			name: "obj",
+			spec: MetaSpec{
+				MetaSpace:  testDir,
+				MetaFile:   externalFile,
+				JSONValue:  false,
+				CacheLocal: true,
+			},
+			key:  "obj",
+			want: `{"abc":"def"}`,
+			validate: func(spec *MetaSpec, got string) {
+				s2, err := spec.Get("obj.abc")
+				s.Require().NoError(err)
+				s.Assert().Equal("def", s2)
+			},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			_ = os.RemoveAll(testDir)
+			s.SetupTest()
+			s.Require().NoError(s.CopyMockFile(externalFile))
+			got, err := tt.spec.Get(tt.key)
+			if tt.wantErr {
+				s.Require().Error(err)
+				return
+			}
+			// Assert that it equals on the first pass.
+			s.Require().NoError(err)
+			s.Assert().Equal(tt.want, got)
+
+			// Get local clone and disable cachedGet then assert again.
+			localClone := tt.spec.CloneDefaultMeta()
+			localClone.CacheLocal = false
+			got, err = tt.spec.Get(tt.key)
+			s.Require().NoError(err)
+			s.Assert().Equal(tt.want, got)
+
+			if tt.validate != nil {
+				tt.validate(&tt.spec, got)
+			}
+		})
+	}
+}

--- a/mock/sd@123:component.json
+++ b/mock/sd@123:component.json
@@ -1,1 +1,1 @@
-{"str":"meow"}
+{"obj":{"abc":"def"},"str":"meow"}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is to handle the case where a scheduled job wishes to trigger the rest of a pipeline as if it were triggered from the component job. If the component writes fields underneath `mycomponentmeta` such as `meta set mycomponentmeta.foo bar` The scheduled job can simply do the following:

```
meta get mycomponentmeta -j --external component --cache-local &> /dev/null
```

And downstream jobs will pick up as if they were downstream of the component job because  `mycomponentmeta` will be filled in.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When `--cache-local` and `--external` flags are used:
1. Check local meta and return if non-null
1. Process external get as usual with local file or fetching
1. Store the return value into the key in local meta.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
