### PR TITLE
display go version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,11 +4,12 @@ shared:
     environment:
         GOPATH: /sd/workspace
         GO111MODULE: on
-        
+
 jobs:
     main:
         requires: [~pr, ~commit]
         steps:
+            - goversion: go version
             - modverify: go mod verify
             - vet: go vet ./...
             - gofmt: (! gofmt -d . | grep '^')


### PR DESCRIPTION
PR adds a step to display the Go version we are using.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
