### PR TITLE
fix(2346): For PR build, lookup job level parameters using parent job name

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -40,6 +40,7 @@ var metaKeyValidator = regexp.MustCompile(`^(\w+([-:]*\w+)*)+(((\[\]|\[(0|[1-9]\
 var rightBracketRegExp = regexp.MustCompile(`\[(.*?)\]`)
 var isNumberRegExp = regexp.MustCompile(`^[+-]?(?:[0-9]*[.])?[0-9]+$`)
 var metaKeyIsParameterRegExp = regexp.MustCompile(`^parameters\.(.+)`)
+var parentJobNameRegExp = regexp.MustCompile(`^(PR-\d+:)?(.+)`)
 
 // MetaSpec encapsulates the parameters usually from CLI so they are more readable and shareable than positional params.
 type MetaSpec struct {
@@ -224,9 +225,11 @@ func (m *MetaSpec) Get(key string) (string, error) {
 
 	if metaKeyIsParameterRegExp.MatchString(key) {
 		// lookup for parameter at job level
-		re := metaKeyIsParameterRegExp.FindStringSubmatch(key)
+		param_re := metaKeyIsParameterRegExp.FindStringSubmatch(key)
 		jobName, _ := m.Get("build.jobName")
-		_, result := fetchMetaValue(fmt.Sprintf("parameters.%s.%s", jobName, re[1]), metaInterface)
+		job_re := parentJobNameRegExp.FindStringSubmatch(jobName)
+		fmt.Fprintln(os.Stderr, job_re[2])
+		_, result := fetchMetaValue(fmt.Sprintf("parameters.%s.%s", job_re[2], param_re[1]), metaInterface)
 
 		// if parameter is not defined at job level, lookup at pipeline level
 		if result != nil {

--- a/meta_test.go
+++ b/meta_test.go
@@ -18,20 +18,21 @@ import (
 )
 
 const (
-	testFile               = "meta"
-	testDir                = "./_test"
-	testFilePath           = testDir + "/" + testFile + ".json"
-	mockDir                = "./mock"
-	externalFile           = "sd@123:component"
-	externalFilePath       = testDir + "/" + externalFile + ".json"
-	externalFile2          = "sd@123:has-sd"
-	externalFile2Path      = testDir + "/" + externalFile2 + ".json"
-	jobParamsComponentFile = "job-params-component"
-	jobParamsPublishFile   = "job-params-publish"
-	doesNotExistFile       = "woof"
-	mockHTTPDir            = "mockHttp"
-	jobsJSONFile           = "jobs.json"
-	lastSuccessfulMetaFile = "lastSuccessfulMeta.json"
+	testFile                      = "meta"
+	testDir                       = "./_test"
+	testFilePath                  = testDir + "/" + testFile + ".json"
+	mockDir                       = "./mock"
+	externalFile                  = "sd@123:component"
+	externalFilePath              = testDir + "/" + externalFile + ".json"
+	externalFile2                 = "sd@123:has-sd"
+	externalFile2Path             = testDir + "/" + externalFile2 + ".json"
+	jobParamsComponentFile        = "job-params-component"
+	jobParamsPublishFile          = "job-params-publish"
+	jobParamsComponentPRBuildFile = "job-params-component-pr-build"
+	doesNotExistFile              = "woof"
+	mockHTTPDir                   = "mockHttp"
+	jobsJSONFile                  = "jobs.json"
+	lastSuccessfulMetaFile        = "lastSuccessfulMeta.json"
 )
 
 type MetaSuite struct {
@@ -260,6 +261,44 @@ func (s *MetaSuite) TestGetMeta() {
 func (s *MetaSuite) TestGetMetaJobParams() {
 	s.MetaSpec.MetaFile = jobParamsComponentFile
 	s.Require().NoError(s.CopyMockFile(jobParamsComponentFile))
+
+	tests := []struct {
+		key      string
+		desc     string
+		expected string
+		wantErr  bool
+	}{
+		{
+			key:      `parameters.color`,
+			expected: `red`,
+		},
+		{
+			key:      `parameters.car`,
+			expected: `audi`,
+		},
+		{
+			key:      `parameters.notexist`,
+			desc:     `The key does not exist in meta`,
+			expected: `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(niceName(tt.key, tt.desc), func() {
+			got, err := s.MetaSpec.Get(tt.key)
+			if tt.wantErr {
+				s.Require().Error(err)
+				return
+			}
+			s.Require().NoError(err)
+			s.Assert().Equal(tt.expected, got)
+		})
+	}
+}
+
+func (s *MetaSuite) TestGetMetaJobParamsForPRBuild() {
+	s.MetaSpec.MetaFile = jobParamsComponentPRBuildFile
+	s.Require().NoError(s.CopyMockFile(jobParamsComponentPRBuildFile))
 
 	tests := []struct {
 		key      string

--- a/mock/job-params-component-pr-build.json
+++ b/mock/job-params-component-pr-build.json
@@ -1,0 +1,1 @@
+{"obj":{"abc":"def"},"str":"meow","build":{"jobName":"PR-3:component"},"parameters":{"color":"white","component":{"color":"red","car":"audi"},"publish":{"car":"mercedes"}}}


### PR DESCRIPTION

## Context
With changes made in https://github.com/screwdriver-cd/models/pull/521, 
the job level parameters are always stored under original/parent job name in `meta` .

## Objective

To lookup job level parameters in `meta`, we should use original/parent job name (Ex: `component`) instead of build job name (Ex: `PR-3:component`).

## References

https://github.com/screwdriver-cd/screwdriver/issues/2346
https://github.com/screwdriver-cd/models/pull/521
https://github.com/screwdriver-cd/meta-cli/pull/46

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
