### PR TITLE
Pull in latest gopher-lua-libs to get shellescape module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	github.com/tidwall/gjson v1.9.3
-	github.com/vadv/gopher-lua-libs v0.1.2
+	github.com/vadv/gopher-lua-libs v0.1.3-0.20220321153755-354f4b160461
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
@@ -16,6 +16,7 @@ require (
 
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.32.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cbroglie/mustache v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/aws/aws-sdk-go v1.32.1 h1:0dy5DkMKNPH9mLWveAWA9ZTiKIEEvJJA6fbe0eCs19k=
 github.com/aws/aws-sdk-go v1.32.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -125,6 +127,8 @@ github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/vadv/gopher-lua-libs v0.1.2 h1:GtgoNMBRWKiNvJaF1XYC3P6CQXVM+qHWhzo0qRTDoaE=
 github.com/vadv/gopher-lua-libs v0.1.2/go.mod h1:Wml8/r0M04zbntX7PPjc39rym765gHCnvb00Bogje1g=
+github.com/vadv/gopher-lua-libs v0.1.3-0.20220321153755-354f4b160461 h1:ADx72AslgXkaGvx98SkH3p+ujdEJ8AzjmVQM2oujN2c=
+github.com/vadv/gopher-lua-libs v0.1.3-0.20220321153755-354f4b160461/go.mod h1:WOiQXSpkMOVfr3TXnmCiFAHWtsFlcxs7uzXFdfLzgK0=
 github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7 h1:noHsffKZsNfU38DwcXWEPldrTjIZ8FPNKx8mYMGnqjs=
 github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7/go.mod h1:bbMEM6aU1WDF1ErA5YJ0p91652pGv140gGw4Ww3RGp8=
 github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=


### PR DESCRIPTION
In order to convert parameters to shell environment a la ENV_VAR='some value', pull in the latest gopher-lua-libs to get shellescape.


## Context

Use-case is to convert params into source-able shell script that looks something like the following, with values properly escaped:

```bash
SOME_KEY='some value'
```

## Objective

Pulls in the version of gopher-lua-libs with [shellescape](https://github.com/alessio/shellescape) support.

## References

https://github.com/vadv/gopher-lua-libs/pull/23

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
