### PR TITLE
Try older version of goreleaser to see if it unsticks us.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,7 +23,7 @@ jobs:
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - tag: ./ci/git-tag.sh
-            - release: "curl -sL https://git.io/goreleaser | bash"
+            - release: "curl -sL https://git.io/goreleaser | VERSION=v1.6.3 bash"
         secrets:
             # Pushing tags to Git
             - GIT_KEY


### PR DESCRIPTION
## Context

goreleaser fails currently even with the last good build; try reverting to an older version that was available at the time of the last good build

## Objective

Fix the broken build <https://cd.screwdriver.cd/pipelines/67/builds/783080/steps/release> 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
