### PR TITLE
Allow meta to be used in shebang for lua scripting.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -751,7 +751,14 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	// To allow shebang scripting to use lua, #!/usr/bin/env meta looks to see if the first arg ends with .lua and
+	// inserts the "lua" subcommand in that case.
+	args := os.Args
+	if len(args) >= 2 && strings.HasSuffix(args[1], ".lua") {
+		args = append([]string{args[0], "lua"}, args[1:]...)
+	}
+
+	if err := app.Run(args); err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -17,7 +17,9 @@ jobs:
             - test-setup: go install gotest.tools/gotestsum@latest
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
             - build: go build -a -o $SD_ARTIFACTS_DIR/meta
-            - test-shebang: ./test-shebang.lua
+            - test-shebang: |
+                ln -s $SD_ARTIFACTS_DIR/meta ./meta-cli
+                ./test-shebang.lua
 
     publish:
         requires: [main]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -17,6 +17,7 @@ jobs:
             - test-setup: go install gotest.tools/gotestsum@latest
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
             - build: go build -a -o $SD_ARTIFACTS_DIR/meta
+            - test-shebang: ./test-shebang.lua
 
     publish:
         requires: [main]

--- a/test-shebang.lua
+++ b/test-shebang.lua
@@ -1,0 +1,3 @@
+#!./meta-cli
+
+print("hello world")


### PR DESCRIPTION
## Context

- Making larger meta commands, such as loading from json file or yaml file, can be possible with lua.
- The current mechanism for commands, requires a single file to be used for binary commands.
- Having lua code in a file suffixed with `.lua` helps most editors/IDEs to write more easily.

Therefore, it would be really nice to be able to have sd commands be written like:

```lua
#!/usr/bin/env meta

print("hello world")
```

## Objective

- Be able to run sd commands as meta lua with shebang `#!/usr/bin/env meta`

## References

Previously, I had tried writing commands using `env -S` but that's only available in "BSD" forks of unix like mac; not on most linux images.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
