### PR TITLE
Build for arm64 as well.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
## Context

M1 macs are arm64, and some arm nodes in public cloud may be cheaper… if building is as easy as requesting it of the goreleaser, then just do that

## Objective

Make arm64 versions for mac and linux.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
