### PR TITLE
Just ensure that the jobName exists (before it was looking up "null").

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -241,12 +241,13 @@ func (m *MetaSpec) cleanParameters(metaInterface map[string]interface{}) (map[st
 	// Override the values with job-specific ones for this jobName
 	_, buildJobName := fetchMetaValue("build.jobName", metaInterface)
 	if jobName, ok := buildJobName.(string); ok {
-		jobRE := parentJobNameRegExp.FindStringSubmatch(jobName)
-		jobName = jobRE[2]
-		if _, jobParameters := fetchMetaValue(jobName, parameters); jobParameters != nil {
-			copyParamValuesIntoMap(ret, jobParameters)
-		} else {
-			logrus.Tracef("No jobParameters for jobName: %s", jobName)
+		if jobRE := parentJobNameRegExp.FindStringSubmatch(jobName); jobRE != nil {
+			jobName = jobRE[2]
+			if _, jobParameters := fetchMetaValue(jobName, parameters); jobParameters != nil {
+				copyParamValuesIntoMap(ret, jobParameters)
+			} else {
+				logrus.Tracef("No jobParameters for jobName: %s", jobName)
+			}
 		}
 	}
 	return ret, nil

--- a/meta.go
+++ b/meta.go
@@ -227,7 +227,7 @@ func copyParamValuesIntoMap(dst map[string]interface{}, src interface{}) {
 }
 
 //cleanParameters copies keys with values (not job keys) are copied and overrides the current job's params, if any.
-func (m *MetaSpec) cleanParameters(metaInterface map[string]interface{}) (map[string]interface{}, error) {
+func cleanParameters(metaInterface map[string]interface{}) (map[string]interface{}, error) {
 	// Ensure paramters exist; otherwise warn and return without error
 	_, parameters := fetchMetaValue("parameters", metaInterface)
 	if parameters == nil {
@@ -276,7 +276,7 @@ func (m *MetaSpec) Get(key string) (string, error) {
 	// Adjust the metaInterface and key to the cleaned parameters and subkey and fall through to normal return
 	if metaKeyIsParameterRegExp.MatchString(key) {
 		// Fetch and clean the parameters from the metaInterface
-		metaInterface, err = m.cleanParameters(metaInterface)
+		metaInterface, err = cleanParameters(metaInterface)
 		if err != nil {
 			return "", err
 		}

--- a/meta.go
+++ b/meta.go
@@ -239,13 +239,15 @@ func (m *MetaSpec) cleanParameters(metaInterface map[string]interface{}) (map[st
 	copyParamValuesIntoMap(ret, parameters)
 
 	// Override the values with job-specific ones for this jobName
-	jobName, _ := m.Get("build.jobName")
-	jobRE := parentJobNameRegExp.FindStringSubmatch(jobName)
-	jobName = jobRE[2]
-	if _, jobParameters := fetchMetaValue(jobName, parameters); jobParameters != nil {
-		copyParamValuesIntoMap(ret, jobParameters)
-	} else {
-		logrus.Tracef("No jobParameters for jobName: %s", jobName)
+	_, buildJobName := fetchMetaValue("build.jobName", metaInterface)
+	if jobName, ok := buildJobName.(string); ok {
+		jobRE := parentJobNameRegExp.FindStringSubmatch(jobName)
+		jobName = jobRE[2]
+		if _, jobParameters := fetchMetaValue(jobName, parameters); jobParameters != nil {
+			copyParamValuesIntoMap(ret, jobParameters)
+		} else {
+			logrus.Tracef("No jobParameters for jobName: %s", jobName)
+		}
 	}
 	return ret, nil
 }


### PR DESCRIPTION
## Context

The previous commit #59 worked because "null" typically didn't match any real jobnames, but, if we use the lower-level `fetchMetaValue` method, we can tell the difference between `nil` the missing value and `"null"` the string value.

## Objective

Small cleanup to just check that the build.jobName is set before looking it up in the original `parameters`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
