### PR TITLE
Upgrade gopher-lua-libs for base64 support (and json/yaml file-io encoder/decoder).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	github.com/tidwall/gjson v1.9.3
-	github.com/vadv/gopher-lua-libs v0.1.3
+	github.com/vadv/gopher-lua-libs v0.1.6
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/vadv/gopher-lua-libs v0.1.3 h1:OLJolSiIXZY8/ebRwNLkygMnxNByvDS5kaLYtsWKn58=
 github.com/vadv/gopher-lua-libs v0.1.3/go.mod h1:WOiQXSpkMOVfr3TXnmCiFAHWtsFlcxs7uzXFdfLzgK0=
+github.com/vadv/gopher-lua-libs v0.1.6 h1:kk17fKHc6LIMJ13qzh7UCvZj0IxQro8CedbluThMnzU=
+github.com/vadv/gopher-lua-libs v0.1.6/go.mod h1:R2oDQhErWoTpAxLKkmFYLd572cO6FVi3QQaat/bQev4=
 github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7 h1:noHsffKZsNfU38DwcXWEPldrTjIZ8FPNKx8mYMGnqjs=
 github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7/go.mod h1:bbMEM6aU1WDF1ErA5YJ0p91652pGv140gGw4Ww3RGp8=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
@@ -152,6 +154,8 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886 h1:eJv7u3ksNXoLbGSKuv2s/SIO4tJVxc/A+MTpzxDgz/Q=
+golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
[This PR](https://github.com/vadv/gopher-lua-libs/pull/31) in the lua libs added lua support for Base64, which can be useful for slurping in binary files to meta values as base64 strings.

Furthermore, that PR added file I/O for base64, json and yaml via the Encoder/Decoder pattern for things to go straight to/from file to the right representation without going through string first.

## Context

There are some use-cases that desire putting json/yaml files or small binary files in meta keys for reference or downstream communication. Being able to go straight from file to meta (or vice versa) helps avoid CLI escaping in the process.

This change upgrades to the latest release to get these features in meta.

## Objective

- Add support for Base64, and file I/O encoder/decoder to json/yaml.

## References

- https://github.com/vadv/gopher-lua-libs/pull/31

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
