### PR TITLE
Add brew generation to goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+brews: []
 builds:
   - binary: meta
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,15 @@
-brews: []
+brews:
+  - tap:
+      owner: screwdriver-cd
+      name: meta-cli
+    folder: Formula
+    homepage: https://github.com/screwdriver-cd/meta-cli
+    description: CLI for reading/writing Screwdriver project metadata
+    download_strategy: CurlDownloadStrategy
+    install: |
+      bin.install "meta-cli" => "meta"
+    test: |
+      system "#{bin}/meta-cli", "--version"
 builds:
   - binary: meta
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ brews:
     homepage: https://github.com/screwdriver-cd/meta-cli
     description: CLI for reading/writing Screwdriver project metadata
     install: |
-      bin.install "meta-cli" => "meta"
+      bin.install File.basename(@stable.url) => "meta"
     test: |
       system "#{bin}/meta-cli", "--version"
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ brews:
     folder: Formula
     homepage: https://github.com/screwdriver-cd/meta-cli
     description: CLI for reading/writing Screwdriver project metadata
-    download_strategy: CurlDownloadStrategy
     install: |
       bin.install "meta-cli" => "meta"
     test: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,13 @@ brews:
     description: CLI for reading/writing Screwdriver project metadata
     install: |
       bin.install File.basename(@stable.url) => "meta"
+      ohai 'Notice', <<~EOL
+        In order to use, you may wish to add the following to your ~/.bash_profile and execute now
+
+          export SD_META_DIR="$HOME/meta"
+          mkdir -p "$SD_META_DIR"
+
+      EOL
     test: |
       system "#{bin}/meta-cli", "--version"
 builds:


### PR DESCRIPTION
## Context

In order to install `meta` locally, generate a homebrew Formula during goreleaser release

## Objective

- Create a homebrew formula, which can be tapped and installed to get `brew` on a laptop.

## References

- https://goreleaser.com/customization/homebrew/?h=homebrew

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
