### PR TITLE
Adjust the commit message to stop the infinite loop of release => push formula => commit => release…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ brews:
     folder: Formula
     homepage: https://github.com/screwdriver-cd/meta-cli
     description: CLI for reading/writing Screwdriver project metadata
+    commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install File.basename(@stable.url) => "meta"
       ohai 'Notice', <<~EOL


### PR DESCRIPTION
Followup to #63 to stop infinite loop

## Context

Without this, releases push a formula, which triggers another build/release.

## Objective

Pushing the formula should not cause a `~commit` trigger

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
