### PR TITLE
fix: Exit with fail if the number of arguments is invalid

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -688,7 +688,8 @@ func main() {
 
 				if c.NArg() != 1 {
 					logrus.Error("meta get expects exactly one argument (key)")
-					return cli.ShowCommandHelp(c, "get")
+					cli.ShowCommandHelp(c, "get")
+					failureExit(nil)
 				}
 				key := c.Args().Get(0)
 				if valid := validateMetaKey(key); !valid {
@@ -726,7 +727,8 @@ func main() {
 
 				if c.NArg() != 2 {
 					logrus.Error("meta set expects exactly two arguments (key, value)")
-					return cli.ShowCommandHelp(c, "set")
+					cli.ShowCommandHelp(c, "set")
+					failureExit(nil)
 				}
 				key := c.Args().Get(0)
 				val := c.Args().Get(1)
@@ -755,7 +757,8 @@ func main() {
 
 				if c.NArg() != 0 {
 					logrus.Error("meta dump expects no arguments")
-					return cli.ShowCommandHelp(c, "dump")
+					cli.ShowCommandHelp(c, "dump")
+					failureExit(nil)
 				}
 
 				if _, err := fetch.ParseJobDescription(metaSpec.LastSuccessfulMetaRequest.DefaultSdPipelineID, metaSpec.MetaFile); metaSpec.IsExternal() && err != nil {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, meta-cli exit without fail if the number of arguments is invalid.
It should exit with fail if the number of arguments is invalid.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Exit with fail if the number of arguments is invalid.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
