### PR TITLE
Use the tests helpers from gopher-lua-libs and its suite lua class.

### DIFF
--- a/lua_test.go
+++ b/lua_test.go
@@ -34,19 +34,21 @@ func (s *LuaSuite) TearDownTest() {
 	s.Require().NoError(os.RemoveAll(s.MetaSpec.MetaSpace))
 }
 
+func preloadMetaForTest(t *testing.T) tests.PreloadFunc {
+	return func(L *lua.LState) {
+		luaSpec := &LuaSpec{
+			MetaSpec: &MetaSpec{
+				JSONValue: true,
+				MetaSpace: testDir,
+				MetaFile:  testFile,
+			},
+		}
+		require.NoError(t, luaSpec.initState(L))
+	}
+}
+
 func TestLua(t *testing.T) {
-	preload := tests.SeveralPreloadFuncs(
-		func(L *lua.LState) {
-			luaSpec := &LuaSpec{
-				MetaSpec: &MetaSpec{
-					JSONValue: true,
-					MetaSpace: testDir,
-					MetaFile:  testFile,
-				},
-			}
-			require.NoError(t, luaSpec.initState(L))
-		},
-	)
+	preload := preloadMetaForTest(t)
 	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "testdata/test.lua"))
 }
 


### PR DESCRIPTION
## Context

The latest gopher-lua-libs also adds test `suite.Suite` and `testing.T.TempDir` making it possible to reduce hand-crafted infra here for invoking the tests - the `test.lua` can just have the suite subclass with SetupTest method to assign the `MetaSpace` to a `TempDir` so it's "fresh" for every test.

## Objective

Uses https://github.com/vadv/gopher-lua-libs test infra for invoking tests written in lua from go

## References

- https://github.com/vadv/gopher-lua-libs/pull/51

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
