### PR TITLE
Ensure that json is not just preloaded but actually loaded so that, when using its methods, it is able to use registered types.

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	libs "github.com/vadv/gopher-lua-libs"
 	"github.com/vadv/gopher-lua-libs/json"
-	"io/ioutil"
 
 	"github.com/screwdriver-cd/meta-cli/internal/fetch"
 	lua "github.com/yuin/gopher-lua"
@@ -341,6 +342,12 @@ func callMethodLGFunction(ud *lua.LUserData, methodName string, nret int) lua.LG
 func (l *LuaSpec) initState(L *lua.LState) error {
 	// Preload the libs libraries
 	libs.Preload(L)
+	// Ensure that json is initialized since we use its methods
+	// Without this, if cli did meta set -j foo {}, then lua's meta.set("foo", meta.get("foo")) would set to [].
+	if err := L.DoString(`require "json"`); err != nil {
+		return err
+	}
+	L.Pop(L.GetTop())
 
 	// Register the MetaSpec TypeMetatable
 	registerMetaSpecType(L)

--- a/lua_test.go
+++ b/lua_test.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/vadv/gopher-lua-libs/tests"
 	lua "github.com/yuin/gopher-lua"
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
 )
 
 type LuaSuite struct {
@@ -62,6 +63,18 @@ func (s *LuaSuite) TestArg_Passing() {
 
 func (s *LuaSuite) TestArg_Passing_Json() {
 	s.Assert().NoError(s.LuaSpec.Do("testdata/test-arg-passing-json.lua", `{"foo": "bar", "bar": [1, 2, 3.45]}`))
+}
+
+func (s *LuaSuite) TestSetEmptyObjectIsObject() {
+	s.MetaSpec.JSONValue = true
+	s.Require().NoError(s.MetaSpec.Set("foo", "{}"))
+	s.MetaSpec.JSONValue = false
+
+	s.LuaSpec.EvaluateString = `meta.set("foo", meta.get("foo"))`
+	s.Require().NoError(s.LuaSpec.Do())
+	foo, err := s.MetaSpec.Get("foo")
+	s.Require().NoError(err)
+	s.Equal("{}", foo)
 }
 
 func (s *LuaSuite) TestCLI() {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
```bash
$ meta set -j foo {}
$ meta get foo | jq .
{}
$ meta lua -E 'meta.set("foo", meta.get("foo"))'
$ meta get foo | jq .
[]
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In lua, tables are actually "associative arrays" - used for both slices and maps (See [Values and Types](https://www.lua.org/manual/5.1/manual.html#2.2)).

An empty table is ambiguous for whether that should represent json `[]` or `{}`.  The gopher-lua-libs json lib sets a metatable to mark a table as coming from an object when decoding, and, when encoding, checks this marshaling empty values to distinguish between array and map.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
