### PR TITLE
fix: Update Goreleaser config to v2 format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,13 @@
+version: 2
+
 brews:
-  - tap:
+  - name: meta
+    repository:
       owner: screwdriver-cd
       name: meta-cli
-    folder: Formula
+    directory: Formula
     homepage: https://github.com/screwdriver-cd/meta-cli
     description: CLI for reading/writing Screwdriver project metadata
-    commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install File.basename(@stable.url) => "meta"
       ohai 'Notice', <<~EOL
@@ -18,7 +20,8 @@ brews:
     test: |
       system "#{bin}/meta-cli", "--version"
 builds:
-  - binary: meta
+  - id: meta
+    binary: meta
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ brews:
     directory: Formula
     homepage: https://github.com/screwdriver-cd/meta-cli
     description: CLI for reading/writing Screwdriver project metadata
+    commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install File.basename(@stable.url) => "meta"
       ohai 'Notice', <<~EOL


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
After updating the Go version, the following error started occurring:
https://cd.screwdriver.cd/pipelines/67/builds/982951/steps/release

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This change updates the Goreleaser configuration to the v2 format.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
