### PR TITLE
fix: remove obsolete toolchain directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/screwdriver-cd/meta-cli
 
 go 1.25
 
-toolchain go1.23.3
-
 require (
 	github.com/gofrs/flock v0.12.1
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
## Context
The Go version was updated to 1.25 in [this PR](https://github.com/screwdriver-cd/meta-cli/pull/88), but the old toolchain directive remained in `go.mod`. 
In our environment, this outdated directive causes Snyk scans to incorrectly detect Go 1.23 standard library vulnerabilities, such as:
- https://security.snyk.io/vuln/SNYK-GOLANG-STDNETURL-15139468

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR removes the outdated toolchain directive.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
