### PR TITLE
feat(3504): Allow @ in meta key validation

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -36,7 +36,7 @@ var (
 	date    = "unknown"
 )
 
-var metaKeyValidator = regexp.MustCompile(`^(\w+([-:]*\w+)*)+(((\[\]|\[(0|[1-9]\d*)\]))?(\.(\w+([-:]*\w+)*)+)*)*$`)
+var metaKeyValidator = regexp.MustCompile(`^(\w+([\-:@]*\w+)*)+(((\[\]|\[(0|[1-9]\d*)\]))?(\.(\w+([\-:@]*\w+)*)+)*)*$`)
 var rightBracketRegExp = regexp.MustCompile(`\[(.*?)\]`)
 var isNumberRegExp = regexp.MustCompile(`^[+-]?(?:[0-9]*[.])?[0-9]+$`)
 var metaKeyIsParameterRegExp = regexp.MustCompile(`^parameters(:?\.(.+))?`)

--- a/meta_test.go
+++ b/meta_test.go
@@ -764,6 +764,9 @@ func (s *MetaSuite) TestValidateMetaKeyWithAccept() {
 		{`f-o-o[1].bar--baz[2]`},
 		{`1.2.3`},
 		{`foo.b-a-r:baz:1-2-3[]`},
+		{`stage@test`},
+		{`stage@explicit-setup-and-teardown:setup`},
+		{`parameters.stage@test:teardown.test.value`},
 	}
 
 	for _, tt := range tests {
@@ -787,8 +790,10 @@ func (s *MetaSuite) TestValidateMetaKeyWithReject() {
 		{`foo.[]`},
 		{`-foo`},
 		{`foo-[]`},
+		{`foo@[]`},
 		{`foo.-bar`},
 		{`foo.bar-[]`},
+		{`@foo`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Context

`meta-cli` could not handle meta keys containing `@`, even though stage setup/teardown-related parameters may use keys such as `stage@explicit-setup-and-teardown:setup` and `parameters.stage@test:teardown.test.value`.

Because `@` was rejected by the existing meta key validation, users could not access or manipulate these values through `meta-cli`.

## Objective

This PR updates the meta key validation to allow `@` in meta keys while preserving the existing key structure rules.

This PR also adds test coverage for valid keys containing `@`, including real-world stage setup/teardown-style keys, and keeps invalid `@` placements rejected.

## References

- Github issue: https://github.com/screwdriver-cd/screwdriver/issues/3504

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.